### PR TITLE
feat: restructure project as monorepo with separate packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,211 +1,169 @@
 # Entity Store
 
-A lightweight, ORM-agnostic entity management system with adapters for popular state managers.
-
-## 🚀 Features
-
-- **ORM Agnostic**: Works with any data structure that has an `id` field
-- **TypeScript First**: Fully typed with excellent IntelliSense support
-- **Multiple Adapters**: Support for Pinia, Redux, Zustand, Jotai, and Valtio (Pinia ready, others coming soon)
-- **Comprehensive API**: Rich set of getters and actions for entity management
-- **Dirty State Tracking**: Built-in support for tracking modified entities
-- **Active Entity Management**: Support for current and active entity selection
-- **Fully Tested**: Comprehensive test coverage for all core functionality
-
-## 📦 Installation
-
-```bash
-pnpm add entity-store
-```
+ORM-agnostic entity management system with adapters for different state managers, organized as a monorepo for better modularity and performance.
 
 ## 🏗️ Architecture
 
-The package is built with a modular architecture:
+The project is organized in separate packages to enable targeted usage and optimal tree-shaking:
 
 ```
-src/
-├── core/           # Core entity management functions
-│   ├── createState.ts    # State initialization
-│   ├── createGetters.ts  # Query and retrieval functions
-│   └── createActions.ts  # Mutation and update functions
-├── types/          # TypeScript type definitions
-├── adapters/       # State manager adapters
-│   ├── pinia/      # Pinia adapter (ready)
-│   ├── redux/      # Redux adapter (coming soon)
-│   ├── zustand/    # Zustand adapter (coming soon)
-│   ├── jotai/      # Jotai adapter (coming soon)
-│   └── valtio/     # Valtio adapter (coming soon)
-└── utils/          # Utility functions
+entity-store/
+├── packages/
+│   ├── core/           # Pure business logic, 0 dependencies
+│   ├── types/          # Shared types
+│   ├── pinia-adapter/  # Pinia adapter
+│   └── main/           # Main package with conditional exports
 ```
 
-## 🎯 Core Concepts
+## 📦 Available Packages
 
-### Entity State Structure
+### @entity-store/core
+Agnostic package containing entity management business logic.
+
+```bash
+npm install @entity-store/core
+```
+
+**Features:**
+- `createState()` : Initial state creation
+- `createActions()` : CRUD actions for entities
+- `createGetters()` : Getters for retrieving and filtering data
+
+### @entity-store/types
+Shared types and interfaces.
+
+```bash
+npm install @entity-store/types
+```
+
+**Types:**
+- `WithId` : Base interface for all entities
+- `State` : Entity state structure
+- `FilterFn` : Types for filtering functions
+
+### @entity-store/pinia-adapter
+Pinia adapter with all core functionality.
+
+```bash
+npm install @entity-store/pinia-adapter pinia
+```
+
+**Features:**
+- Complete Pinia store with entity management
+- Customizable extensions (state, getters, actions)
+- Native integration with Vue ecosystem
+
+### entity-store (main package)
+Main package that exports everything, for simple usage.
+
+```bash
+npm install entity-store
+```
+
+## 🚀 Quick Start
+
+### With Pinia (recommended)
 
 ```typescript
-interface State<T extends WithId> {
-  entities: {
-    byId: Record<Id, T & { $isDirty: boolean }>
-    allIds: Id[]
-    current: (T & { $isDirty: boolean }) | null
-    currentById: Id | null
-    active: Id[]
-  }
-}
-```
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+import type { WithId } from '@entity-store/types'
 
-### Key Features
-
-- **`byId`**: Dictionary of entities indexed by their ID
-- **`allIds`**: Array of all entity IDs for iteration
-- **`current`**: Currently selected entity
-- **`currentById`**: ID of the currently selected entity
-- **`active`**: Array of active entity IDs
-- **`$isDirty`**: Flag indicating if an entity has been modified
-
-## 🔧 Usage
-
-### Core Functions
-
-```typescript
-import { createState, createGetters, createActions } from 'entity-store'
-
-// Create state
-const state = createState<User>()
-
-// Create getters and actions
-const getters = createGetters<User>(state)
-const actions = createActions<User>(state)
-
-// Use them
-actions.createOne({ id: 1, name: 'John', email: 'john@example.com' })
-const user = getters.getOne()(1)
-```
-
-### Pinia Adapter (Ready)
-
-```typescript
-import { createPiniaEntityStore } from 'entity-store/adapters/pinia'
-
-interface User {
-  id: number
+interface User extends WithId {
   name: string
   email: string
 }
 
-// Create the store
 const useUserStore = createPiniaEntityStore<User>('users')
 
-// Use in your component
-export default defineComponent({
-  setup() {
-    const userStore = useUserStore()
-    
-    // CRUD operations
-    userStore.createOne({ id: 1, name: 'John', email: 'john@example.com' })
-    userStore.updateOne(1, { name: 'John Updated' })
-    userStore.deleteOne(1)
-    
-    // Querying
-    const allUsers = userStore.getAllArray()
-    const currentUser = userStore.getCurrent()
-    const activeUsers = userStore.getActive()
-    
-    return { userStore, allUsers, currentUser, activeUsers }
-  }
-})
+// In a Vue component
+const userStore = useUserStore()
+userStore.createOne({ id: 1, name: 'John', email: 'john@example.com' })
 ```
 
-## 📚 API Reference
+### With Core (agnostic)
 
-### Core Getters
+```typescript
+import { createState, createActions, createGetters } from '@entity-store/core'
+import type { WithId } from '@entity-store/types'
 
-- **`getAll()`**: Get all entities as dictionary
-- **`getAllArray()`**: Get all entities as array
-- **`getAllIds()`**: Get array of all entity IDs
-- **`getOne(id)`**: Get single entity by ID
-- **`getMany(ids)`**: Get multiple entities by IDs
-- **`getCurrent()`**: Get currently selected entity
-- **`getCurrentById()`**: Get entity by current ID
-- **`getActive()`**: Get array of active entity IDs
-- **`getWhere(filter)`**: Filter entities by predicate
-- **`getMissingIds(ids)`**: Find IDs not in store
-- **`getMissingEntities(entities)`**: Find entities not in store
+interface User extends WithId {
+  name: string
+  email: string
+}
 
-### Core Actions
+const state = createState<User>()
+const actions = createActions<User>(state)
+const getters = createGetters<User>(state)
 
-- **`createOne(entity)`**: Create single entity
-- **`createMany(entities)`**: Create multiple entities
-- **`updateOne(id, updates)`**: Update entity by ID
-- **`updateMany(entities)`**: Update multiple entities
-- **`deleteOne(id)`**: Delete entity by ID
-- **`deleteMany(ids)`**: Delete multiple entities
-- **`setCurrent(entity)`**: Set current entity
-- **`setCurrentById(id)`**: Set current entity by ID
-- **`setActive(id)`**: Set entity as active
-- **`resetActive()`**: Clear all active entities
-- **`setIsDirty(id)`**: Mark entity as modified
-- **`setIsNotDirty(id)`**: Mark entity as unmodified
+// Usage
+actions.createOne({ id: 1, name: 'John', email: 'john@example.com' })
+const user = getters.getOne()(1)
+```
 
-## 🧪 Testing
+## 🎯 Benefits of this Architecture
+
+### **Optimal Tree-shaking**
+- Import only what you need
+- Minimal bundle size for production
+
+### **Isolated Dependencies**
+- Each package manages its own dependencies
+- No conflicts between state managers
+
+### **Scalability**
+- Easy addition of new adapters
+- Simplified maintenance per package
+
+### **Usage Flexibility**
+- Use core alone for an agnostic solution
+- Or a specific adapter for native integration
+
+## 🔧 Development
+
+### Install dependencies
 
 ```bash
-# Run all tests
-pnpm test
-
-# Run tests in watch mode
-pnpm test:watch
-
-# Run tests with coverage
-pnpm test:coverage
-
-# Type checking
-pnpm type-check
+pnpm install
 ```
 
-## 📖 Examples
+### Build all packages
 
-See the `examples/` directory for complete usage examples:
+```bash
+pnpm build
+```
 
-- **`examples/pinia-usage.ts`**: Complete Pinia adapter demonstration
-- **`src/adapters/pinia/example.ts`**: Pinia adapter usage patterns
+### Tests
 
-## 🔮 Roadmap
+```bash
+pnpm test
+```
 
-### Phase 1: Core & Pinia ✅
-- [x] Core entity management functions
-- [x] Comprehensive test coverage
-- [x] Pinia adapter
-- [x] TypeScript support
-- [x] Documentation
+### Development in watch mode
 
-### Phase 2: Additional Adapters 🚧
-- [ ] Redux adapter
-- [ ] Zustand adapter
-- [ ] Jotai adapter
-- [ ] Valtio adapter
+```bash
+pnpm dev
+```
 
-### Phase 3: Advanced Features 📋
-- [ ] Pagination support
-- [ ] Relationship management
-- [ ] Caching strategies
-- [ ] Performance optimizations
+## 📚 Documentation
+
+- [Core Documentation](./packages/core/README.md)
+- [Types Documentation](./packages/types/README.md)
+- [Pinia Adapter Documentation](./packages/pinia-adapter/README.md)
+
+## 🚧 Roadmap
+
+- [ ] Zustand Adapter
+- [ ] Redux Toolkit Adapter
+- [ ] Jotai Adapter
+- [ ] Valtio Adapter
+- [ ] Pinia Plugin
+- [ ] Migration tools
+- [ ] Integration examples
 
 ## 🤝 Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+Contributions are welcome! Each package can be developed and tested independently.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- Inspired by modern state management patterns
-- Built with TypeScript and modern JavaScript features
-- Comprehensive testing with Vitest
-- Clean architecture principles
+MIT

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -1,0 +1,192 @@
+# Installation Guide
+
+This guide explains how to install and use entity-store packages based on your needs.
+
+## Package Options
+
+### Option 1: Install everything (Recommended for beginners)
+
+```bash
+npm install entity-store
+# or
+pnpm add entity-store
+# or
+yarn add entity-store
+```
+
+**Use when:**
+- You want to try all features
+- You're building a new project
+- You don't mind the larger bundle size
+
+**Import:**
+```typescript
+import { createPiniaEntityStore } from 'entity-store'
+import type { WithId } from 'entity-store'
+```
+
+### Option 2: Install only what you need (Recommended for production)
+
+#### For Pinia users:
+```bash
+npm install @entity-store/pinia-adapter pinia
+# or
+pnpm add @entity-store/pinia-adapter pinia
+# or
+yarn add @entity-store/pinia-adapter pinia
+```
+
+**Import:**
+```typescript
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+import type { WithId } from '@entity-store/types'
+```
+
+#### For agnostic usage (any state manager):
+```bash
+npm install @entity-store/core @entity-store/types
+# or
+pnpm add @entity-store/core @entity-store/types
+# or
+yarn add @entity-store/core @entity-store/types
+```
+
+**Import:**
+```typescript
+import { createState, createActions, createGetters } from '@entity-store/core'
+import type { WithId } from '@entity-store/types'
+```
+
+#### For types only:
+```bash
+npm install @entity-store/types
+# or
+pnpm add @entity-store/types
+# or
+yarn add @entity-store/types
+```
+
+**Import:**
+```typescript
+import type { WithId, State, FilterFn } from '@entity-store/types'
+```
+
+## Bundle Size Comparison
+
+| Package | Size | Use Case |
+|---------|------|----------|
+| `@entity-store/types` | ~2KB | Types only |
+| `@entity-store/core` | ~15KB | Core logic |
+| `@entity-store/pinia-adapter` | ~20KB | Pinia integration |
+| `entity-store` (all) | ~40KB | Everything |
+
+## Migration from v1.0.0
+
+If you're upgrading from the previous single-package version:
+
+### Before (v1.0.0):
+```typescript
+import { createPiniaEntityStore } from 'entity-store'
+```
+
+### After (v2.0.0):
+```typescript
+// Option 1: Keep using the main package
+import { createPiniaEntityStore } from 'entity-store'
+
+// Option 2: Use the specific adapter (recommended)
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+```
+
+## Framework-Specific Setup
+
+### Vue 3 + Pinia
+
+```bash
+npm install @entity-store/pinia-adapter pinia
+```
+
+```typescript
+import { createPinia } from 'pinia'
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+
+const pinia = createPinia()
+app.use(pinia)
+
+const useUserStore = createPiniaEntityStore<User>('users')
+```
+
+### React + Zustand (coming soon)
+
+```bash
+npm install @entity-store/zustand-adapter zustand
+```
+
+```typescript
+import { createZustandEntityStore } from '@entity-store/zustand-adapter'
+
+const useUserStore = createZustandEntityStore<User>('users')
+```
+
+### Vanilla JavaScript
+
+```bash
+npm install @entity-store/core @entity-store/types
+```
+
+```typescript
+import { createState, createActions, createGetters } from '@entity-store/core'
+
+const state = createState<User>()
+const actions = createActions<User>(state)
+const getters = createGetters<User>(state)
+```
+
+## TypeScript Configuration
+
+Make sure your `tsconfig.json` includes:
+
+```json
+{
+  "compilerOptions": {
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "module": "ESNext",
+    "target": "ES2022"
+  }
+}
+```
+
+## Troubleshooting
+
+### Import errors
+
+If you get import errors, check:
+
+1. **Package name**: Make sure you're using the correct package name
+2. **Dependencies**: Ensure peer dependencies are installed
+3. **TypeScript version**: Use TypeScript 5.0+ for best experience
+
+### Build errors
+
+Common build issues:
+
+1. **Module resolution**: Ensure your bundler supports ESM
+2. **Tree-shaking**: Some bundlers may require specific configuration
+3. **Type declarations**: Make sure `@types` packages are installed if needed
+
+### Performance issues
+
+For optimal performance:
+
+1. **Use specific packages**: Install only what you need
+2. **Enable tree-shaking**: Configure your bundler properly
+3. **Lazy loading**: Import adapters only when needed
+
+## Examples
+
+See the `examples/` directory for complete usage examples:
+
+- [Basic Pinia usage](./examples/pinia-basic-usage.ts)
+- [Core usage](./examples/core-usage.ts) (coming soon)
+- [Zustand usage](./examples/zustand-usage.ts) (coming soon)

--- a/examples/pinia-basic-usage.ts
+++ b/examples/pinia-basic-usage.ts
@@ -1,0 +1,301 @@
+/**
+ * Basic usage example with Pinia
+ * 
+ * This example shows how to use the Pinia adapter
+ * to create and manage a user store.
+ */
+
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+import type { WithId } from '@entity-store/types'
+import { createPinia, setActivePinia, storeToRefs } from 'pinia'
+
+// User interface definition
+interface User extends WithId {
+  name: string
+  email: string
+  age: number
+  role: 'admin' | 'user' | 'moderator'
+}
+
+// Store creation
+const useUserStore = createPiniaEntityStore<User>('users', {
+  // Additional state
+  state: {
+    isLoading: false,
+    error: null as string | null,
+    lastFetch: null as Date | null
+  },
+  
+  // Custom getters
+  getters: {
+    // Get users by role
+    getUsersByRole: (store) => (role: User['role']) => {
+      return store.getAllArray().filter(user => user.role === role)
+    },
+    
+    // Get active users count
+    getActiveUsersCount: (store) => () => {
+      return store.getActive().length
+    },
+    
+    // Get adult users
+    getAdultUsers: (store) => () => {
+      return store.getAllArray().filter(user => user.age >= 18)
+    },
+    
+    // Search users by name
+    searchUsersByName: (store) => (query: string) => {
+      return store.getAllArray().filter(user => 
+        user.name.toLowerCase().includes(query.toLowerCase())
+      )
+    }
+  },
+  
+  // Custom actions
+  actions: {
+    // Load users from API
+    fetchUsers: (store) => async () => {
+      store.$patch({ isLoading: true, error: null })
+      
+      try {
+        // Simulate API call
+        const users: User[] = await mockApiCall()
+        
+        // Add users to store
+        store.createMany(users)
+        
+        // Update state
+        store.$patch({ 
+          lastFetch: new Date(),
+          isLoading: false 
+        })
+      } catch (error) {
+        store.$patch({ 
+          error: error instanceof Error ? error.message : 'Unknown error',
+          isLoading: false 
+        })
+      }
+    },
+    
+    // Create user with validation
+    createUserWithValidation: (store) => (userData: Omit<User, 'id'>) => {
+      // Basic validation
+      if (!userData.name || userData.name.trim().length < 2) {
+        throw new Error('Name must contain at least 2 characters')
+      }
+      
+      if (!userData.email || !userData.email.includes('@')) {
+        throw new Error('Invalid email')
+      }
+      
+      if (userData.age < 13) {
+        throw new Error('Minimum age is 13')
+      }
+      
+      // Generate unique ID (in a real project, this would be managed by the API)
+      const id = Date.now().toString()
+      const user: User = { ...userData, id }
+      
+      // Create user
+      store.createOne(user)
+      
+      // Set as current user
+      store.setCurrent(user)
+      
+      return user
+    },
+    
+    // Update user with validation
+    updateUserWithValidation: (store) => (id: string, updates: Partial<User>) => {
+      const existingUser = store.getOne()(id)
+      if (!existingUser) {
+        throw new Error('User not found')
+      }
+      
+      // Validate updates
+      if (updates.name && updates.name.trim().length < 2) {
+        throw new Error('Name must contain at least 2 characters')
+      }
+      
+      if (updates.email && !updates.email.includes('@')) {
+        throw new Error('Invalid email')
+      }
+      
+      if (updates.age && updates.age < 13) {
+        throw new Error('Minimum age is 13')
+      }
+      
+      // Update user
+      store.updateOne(id, { ...existingUser, ...updates })
+      
+      // Update current entity if it's the same
+      if (store.getCurrent()?.id === id) {
+        store.setCurrent(store.getOne()(id)!)
+      }
+    },
+    
+    // Delete user with confirmation
+    deleteUserWithConfirmation: (store) => (id: string, confirm: boolean) => {
+      if (!confirm) {
+        throw new Error('Confirmation required to delete user')
+      }
+      
+      const user = store.getOne()(id)
+      if (!user) {
+        throw new Error('User not found')
+      }
+      
+      // Delete user
+      store.deleteOne(id)
+      
+      // Reset current entity if it was the same
+      if (store.getCurrent()?.id === id) {
+        store.removeCurrent()
+      }
+      
+      return user
+    }
+  }
+})
+
+// Mock API call simulation
+async function mockApiCall(): Promise<User[]> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        { id: '1', name: 'John Doe', email: 'john@example.com', age: 30, role: 'admin' },
+        { id: '2', name: 'Jane Smith', email: 'jane@example.com', age: 25, role: 'user' },
+        { id: '3', name: 'Bob Johnson', email: 'bob@example.com', age: 35, role: 'moderator' },
+        { id: '4', name: 'Alice Brown', email: 'alice@example.com', age: 28, role: 'user' },
+        { id: '5', name: 'Charlie Wilson', email: 'charlie@example.com', age: 22, role: 'user' }
+      ])
+    }, 1000)
+  })
+}
+
+// Usage example in a Vue component
+export function useUserStoreExample() {
+  // Initialize Pinia
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  
+  // Use store
+  const userStore = useUserStore()
+  
+  // Usage examples
+  
+  // 1. Load users
+  userStore.fetchUsers()
+  
+  // 2. Create new user
+  try {
+    const newUser = userStore.createUserWithValidation({
+      name: 'New User',
+      email: 'newuser@example.com',
+      age: 25,
+      role: 'user'
+    })
+    console.log('User created:', newUser)
+  } catch (error) {
+    console.error('Error during creation:', error)
+  }
+  
+  // 3. Update user
+  try {
+    userStore.updateUserWithValidation('1', { age: 31 })
+    console.log('User updated')
+  } catch (error) {
+    console.error('Error during update:', error)
+  }
+  
+  // 4. Use custom getters
+  const adminUsers = userStore.getUsersByRole('admin')
+  const activeCount = userStore.getActiveUsersCount()
+  const adultUsers = userStore.getAdultUsers()
+  const searchResults = userStore.searchUsersByName('john')
+  
+  console.log('Admins:', adminUsers)
+  console.log('Active users:', activeCount)
+  console.log('Adult users:', adultUsers)
+  console.log('Search results:', searchResults)
+  
+  // 5. Active entities management
+  userStore.setActive('1')
+  userStore.setActive('2')
+  userStore.setActive('3')
+  
+  const activeUsers = userStore.getActive()
+  console.log('Active IDs:', activeUsers)
+  
+  // 6. Current entity management
+  userStore.setCurrentById('1')
+  const currentUser = userStore.getCurrent()
+  console.log('Current user:', currentUser)
+  
+  // 7. Check modification state
+  const isDirty = userStore.isDirty('1')
+  console.log('User 1 modified:', isDirty)
+  
+  // 8. Get state information
+  const isEmpty = userStore.getIsEmpty()
+  const totalUsers = userStore.getAllIds().length
+  console.log('Store empty:', isEmpty)
+  console.log('Total users:', totalUsers)
+  
+  return {
+    userStore,
+    adminUsers,
+    activeCount,
+    adultUsers,
+    searchResults,
+    activeUsers,
+    currentUser,
+    isDirty,
+    isEmpty,
+    totalUsers
+  }
+}
+
+// Usage example in a Vue component with Composition API
+export function useUserStoreInComponent() {
+  const userStore = useUserStore()
+  
+  // Destructure with storeToRefs for reactivity
+  const { entities, isLoading, error, lastFetch } = storeToRefs(userStore)
+  
+  // Actions remain functions
+  const { 
+    fetchUsers, 
+    createUserWithValidation, 
+    updateUserWithValidation,
+    deleteUserWithConfirmation 
+  } = userStore
+  
+  // Custom getters
+  const { 
+    getUsersByRole, 
+    getActiveUsersCount, 
+    getAdultUsers,
+    searchUsersByName 
+  } = userStore
+  
+  return {
+    // Reactive state
+    entities,
+    isLoading,
+    error,
+    lastFetch,
+    
+    // Actions
+    fetchUsers,
+    createUserWithValidation,
+    updateUserWithValidation,
+    deleteUserWithConfirmation,
+    
+    // Custom getters
+    getUsersByRole,
+    getActiveUsersCount,
+    getAdultUsers,
+    searchUsersByName
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,27 +3,15 @@
   "version": "1.0.0",
   "description": "ORM agnostique avec des adaptateurs pour différents state managers",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
-  "files": [
-    "dist"
-  ],
+  "private": true,
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
-    "test": "vitest",
-    "test:watch": "vitest --watch",
-    "test:coverage": "vitest --coverage",
-    "test:run": "vitest run",
-    "type-check": "tsc --noEmit",
-    "clean": "rm -rf dist",
-    "prepublishOnly": "pnpm clean && pnpm build"
+    "build": "pnpm -r build",
+    "dev": "pnpm -r dev",
+    "test": "pnpm -r test",
+    "test:watch": "pnpm -r test:watch",
+    "test:coverage": "pnpm -r test:coverage",
+    "clean": "pnpm -r clean",
+    "type-check": "pnpm -r type-check"
   },
   "keywords": [
     "orm",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,141 @@
+# @entity-store/core
+
+Agnostic core package for entity management, independent of any state manager.
+
+## Installation
+
+```bash
+npm install @entity-store/core
+# or
+pnpm add @entity-store/core
+# or
+yarn add @entity-store/core
+```
+
+## Usage
+
+### Import functions
+
+```typescript
+import { createState, createActions, createGetters } from '@entity-store/core'
+```
+
+### Create state
+
+```typescript
+import { createState } from '@entity-store/core'
+
+// Create initial state
+const state = createState<User>()
+
+// State contains:
+// - entities.byId: Record of entities by ID
+// - entities.allIds: List of IDs
+// - entities.current: Currently selected entity
+// - entities.currentById: ID of current entity
+// - entities.active: List of active IDs
+```
+
+### Create actions
+
+```typescript
+import { createActions } from '@entity-store/core'
+
+const actions = createActions<User>(state)
+
+// Available actions:
+actions.createOne(user)           // Create an entity
+actions.createMany(users)         // Create multiple entities
+actions.updateOne(id, user)       // Update an entity
+actions.updateMany(users)         // Update multiple entities
+actions.deleteOne(id)             // Delete an entity
+actions.deleteMany(ids)           // Delete multiple entities
+actions.setCurrent(user)          // Set current entity
+actions.setCurrentById(id)        // Set current entity by ID
+actions.setActive(id)             // Mark entity as active
+actions.resetActive()             // Reset active entities
+actions.setIsDirty(id)            // Mark entity as modified
+actions.setIsNotDirty(id)         // Mark entity as unmodified
+actions.updateField(field, value, id) // Update a specific field
+```
+
+### Create getters
+
+```typescript
+import { createGetters } from '@entity-store/core'
+
+const getters = createGetters<User>(state)
+
+// Available getters:
+getters.getOne()(id)              // Get entity by ID
+getters.getMany(ids)              // Get multiple entities by IDs
+getters.getAll()                   // Get all entities
+getters.getAllArray()              // Get all entities as array
+getters.getAllIds()                // Get all IDs
+getters.getCurrent()               // Get current entity
+getters.getCurrentById()           // Get current entity by ID
+getters.getActive()                // Get active entities
+getters.getFirstActive()           // Get first active entity
+getters.getWhere(filter)           // Filter entities
+getters.getWhereArray(filter)      // Filter entities as array
+getters.getFirstWhere(filter)      // Get first filtered entity
+getters.getIsEmpty()               // Check if state is empty
+getters.getIsNotEmpty()            // Check if state is not empty
+getters.isAlreadyInStore(id)      // Check if entity exists
+getters.isAlreadyActive(id)        // Check if entity is active
+getters.isDirty(id)                // Check if entity is modified
+getters.search(field)              // Search in entities
+getters.getMissingIds(ids)         // Get missing IDs
+getters.getMissingEntities(entities) // Get missing entities
+```
+
+## Types
+
+```typescript
+interface User extends WithId {
+  name: string
+  email: string
+  age: number
+}
+
+// WithId automatically adds:
+// - id: Id (string | number)
+// - $isDirty: boolean (for modification tracking)
+```
+
+## Complete Example
+
+```typescript
+import { createState, createActions, createGetters } from '@entity-store/core'
+
+interface User extends WithId {
+  name: string
+  email: string
+}
+
+// Create state
+const state = createState<User>()
+
+// Create actions and getters
+const actions = createActions<User>(state)
+const getters = createGetters<User>(state)
+
+// Usage
+const user: User = { id: 1, name: 'John', email: 'john@example.com' }
+
+actions.createOne(user)
+actions.setCurrent(user)
+actions.setActive(1)
+
+const currentUser = getters.getCurrent()
+const allUsers = getters.getAllArray()
+const isActive = getters.isAlreadyActive(1)
+```
+
+## Benefits
+
+- **Agnostic**: Works with any state manager
+- **Type-safe**: Fully typed with TypeScript
+- **Performant**: Optimized logic for entity management
+- **Flexible**: Easily extensible and customizable
+- **Tested**: Complete test coverage

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@entity-store/core",
+  "version": "1.0.0",
+  "description": "Core entity management functions - agnostic to state managers",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest --coverage",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "keywords": [
+    "entity-management",
+    "state-management",
+    "typescript",
+    "agnostic"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/core/src/createActions.test.ts
+++ b/packages/core/src/createActions.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { WithId } from '../types/WithId.js';
+import createActions from './createActions.js';
+import createState from './createState.js';
+
+// Test entity interface
+interface User extends WithId {
+  name: string;
+  email: string;
+  age: number;
+}
+
+describe('createActions', () => {
+  let state: ReturnType<typeof createState<User>>;
+  let actions: ReturnType<typeof createActions<User>>;
+
+  beforeEach(() => {
+    state = createState<User>();
+    actions = createActions(state);
+  });
+
+  describe('createOne', () => {
+    test('should create single entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.createOne(user);
+      
+      expect(state.entities.byId[1]).toBeDefined();
+      expect(state.entities.byId[1]?.name).toBe('John');
+      expect(state.entities.byId[1]?.$isDirty).toBe(false);
+      expect(state.entities.allIds).toContain(1);
+    });
+
+    test('should not duplicate id in allIds if entity already exists', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.createOne(user);
+      actions.createOne(user); // Try to create again
+      
+      expect(state.entities.allIds.filter(id => id === 1)).toHaveLength(1);
+    });
+
+    test('should update existing entity if id already exists', () => {
+      const user1: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      const user2: User = { id: 1, name: 'John Updated', email: 'john.updated@example.com', age: 31 };
+      
+      actions.createOne(user1);
+      actions.createOne(user2);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[1]?.email).toBe('john.updated@example.com');
+      expect(state.entities.byId[1]?.age).toBe(31);
+    });
+  });
+
+  describe('createMany', () => {
+    test('should create multiple entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 },
+        { id: 3, name: 'Bob', email: 'bob@example.com', age: 35 }
+      ];
+      
+      actions.createMany(users);
+      
+      expect(state.entities.allIds).toHaveLength(3);
+      expect(state.entities.allIds).toContain(1);
+      expect(state.entities.allIds).toContain(2);
+      expect(state.entities.allIds).toContain(3);
+      
+      expect(state.entities.byId[1]?.name).toBe('John');
+      expect(state.entities.byId[2]?.name).toBe('Jane');
+      expect(state.entities.byId[3]?.name).toBe('Bob');
+    });
+
+    test('should handle empty array', () => {
+      actions.createMany([]);
+      
+      expect(state.entities.allIds).toHaveLength(0);
+      expect(Object.keys(state.entities.byId)).toHaveLength(0);
+    });
+  });
+
+  describe('setCurrent', () => {
+    test('should set current entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.setCurrent(user);
+      
+      expect(state.entities.current).toBeDefined();
+      expect(state.entities.current?.name).toBe('John');
+      expect(state.entities.current?.$isDirty).toBe(false);
+    });
+
+    test('should update current entity if already set', () => {
+      const user1: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      const user2: User = { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 };
+      
+      actions.setCurrent(user1);
+      actions.setCurrent(user2);
+      
+      expect(state.entities.current?.id).toBe(2);
+      expect(state.entities.current?.name).toBe('Jane');
+    });
+  });
+
+  describe('removeCurrent', () => {
+    test('should remove current entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.setCurrent(user);
+      expect(state.entities.current).toBeDefined();
+      
+      actions.removeCurrent();
+      expect(state.entities.current).toBeNull();
+    });
+
+    test('should handle removing when no current entity', () => {
+      expect(state.entities.current).toBeNull();
+      
+      actions.removeCurrent();
+      expect(state.entities.current).toBeNull();
+    });
+  });
+
+  describe('updateOne', () => {
+    test('should update existing entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      const updatedUser: User = { id: 1, name: 'John Updated', email: 'john.updated@example.com', age: 31 };
+      actions.updateOne(1, updatedUser);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[1]?.email).toBe('john.updated@example.com');
+      expect(state.entities.byId[1]?.age).toBe(31);
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+    });
+
+    test('should create entity if id does not exist', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.updateOne(1, user);
+      
+      expect(state.entities.byId[1]).toBeDefined();
+      expect(state.entities.byId[1]?.name).toBe('John');
+      expect(state.entities.allIds).toContain(1);
+    });
+
+    test('should preserve existing fields not in payload', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      const updatedUser: User = { id: 1, name: 'John Updated', age: 31 } as User;
+      actions.updateOne(1, updatedUser);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[1]?.email).toBe('john@example.com'); // Preserved
+      expect(state.entities.byId[1]?.age).toBe(31);
+    });
+  });
+
+  describe('updateMany', () => {
+    test('should update multiple entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      actions.createMany(users);
+      
+      const updatedUsers: User[] = [
+        { id: 1, name: 'John Updated', email: 'john.updated@example.com', age: 31 },
+        { id: 2, name: 'Jane Updated', email: 'jane.updated@example.com', age: 26 }
+      ];
+      
+      actions.updateMany(updatedUsers);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[2]?.name).toBe('Jane Updated');
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+      expect(state.entities.byId[2]?.$isDirty).toBe(true);
+    });
+
+    test('should handle empty array', () => {
+      actions.updateMany([]);
+      expect(state.entities.allIds).toHaveLength(0);
+    });
+  });
+
+  describe('deleteOne', () => {
+    test('should delete entity by id', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      expect(state.entities.byId[1]).toBeDefined();
+      expect(state.entities.allIds).toContain(1);
+      
+      actions.deleteOne(1);
+      
+      expect(state.entities.byId[1]).toBeUndefined();
+      expect(state.entities.allIds).not.toContain(1);
+    });
+
+    test('should handle deleting non-existent entity', () => {
+      const initialLength = state.entities.allIds.length;
+      
+      actions.deleteOne(999);
+      
+      expect(state.entities.allIds.length).toBe(initialLength);
+    });
+  });
+
+  describe('deleteMany', () => {
+    test('should delete multiple entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 },
+        { id: 3, name: 'Bob', email: 'bob@example.com', age: 35 }
+      ];
+      actions.createMany(users);
+      
+      expect(state.entities.allIds).toHaveLength(3);
+      
+      actions.deleteMany([1, 3]);
+      
+      expect(state.entities.allIds).toHaveLength(1);
+      expect(state.entities.allIds).toContain(2);
+      expect(state.entities.byId[1]).toBeUndefined();
+      expect(state.entities.byId[3]).toBeUndefined();
+      expect(state.entities.byId[2]).toBeDefined();
+    });
+
+    test('should handle empty array', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.deleteMany([]);
+      
+      expect(state.entities.allIds).toContain(1);
+      expect(state.entities.byId[1]).toBeDefined();
+    });
+  });
+
+  describe('setActive', () => {
+    test('should set entity as active', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.setActive(1);
+      
+      expect(state.entities.active).toContain(1);
+    });
+
+    test('should not duplicate active entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.setActive(1);
+      actions.setActive(1); // Try to set again
+      
+      expect(state.entities.active.filter(id => id === 1)).toHaveLength(1);
+    });
+
+    test('should handle non-existent entity', () => {
+      actions.setActive(999);
+      expect(state.entities.active).toHaveLength(0);
+    });
+  });
+
+  describe('resetActive', () => {
+    test('should clear all active entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      actions.createMany(users);
+      
+      actions.setActive(1);
+      actions.setActive(2);
+      
+      expect(state.entities.active).toHaveLength(2);
+      
+      actions.resetActive();
+      
+      expect(state.entities.active).toHaveLength(0);
+    });
+
+    test('should handle reset when no active entities', () => {
+      expect(state.entities.active).toHaveLength(0);
+      
+      actions.resetActive();
+      
+      expect(state.entities.active).toHaveLength(0);
+    });
+  });
+
+  describe('setIsDirty', () => {
+    test('should mark entity as dirty', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      expect(state.entities.byId[1]?.$isDirty).toBe(false);
+      
+      actions.setIsDirty(1);
+      
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+    });
+
+    test('should handle non-existent entity', () => {
+      actions.setIsDirty(999);
+      // Should not throw error
+    });
+  });
+
+  describe('setIsNotDirty', () => {
+    test('should mark entity as not dirty', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.setIsDirty(1);
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+      
+      actions.setIsNotDirty(1);
+      
+      expect(state.entities.byId[1]?.$isDirty).toBe(false);
+    });
+
+    test('should handle non-existent entity', () => {
+      actions.setIsNotDirty(999);
+      // Should not throw error
+    });
+  })
+
+  describe('Integration tests', () => {
+    test('should handle complex workflow', () => {
+      // Create entities
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      actions.createMany(users);
+      
+      // Set current and active
+      actions.setCurrent(users[0]);
+      actions.setActive(1);
+      actions.setActive(2);
+      
+      // Update entity
+      actions.updateOne(1, { id: 1, name: 'John Updated', email: 'john@example.com', age: 31 });
+      
+      // Verify state
+      expect(state.entities.allIds).toHaveLength(2);
+      expect(state.entities.current?.name).toBe('John');
+      expect(state.entities.active).toHaveLength(2);
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+      
+      // Delete entity
+      actions.deleteOne(2);
+      
+      expect(state.entities.allIds).toHaveLength(1);
+      expect(state.entities.active).toHaveLength(1);
+      expect(state.entities.byId[2]).toBeUndefined();
+    });
+  });
+});
+

--- a/packages/core/src/createActions.ts
+++ b/packages/core/src/createActions.ts
@@ -1,0 +1,157 @@
+import type { State } from './types/State.js'
+import type { Id, WithId } from './types/WithId.js'
+
+export default function createActions<T extends WithId>(state: State<T>) {
+  return {
+    /**
+   * Create single entity in Store
+   * @param payload Entity to create
+   */
+    createOne(payload: T): void {
+      if (!state.entities.byId[payload.id] && !state.entities.allIds.includes(payload.id)) {
+        state.entities.allIds.push(payload.id)
+      }
+      state.entities.byId[payload.id] = { ...payload, $isDirty: false }
+    },
+
+    /**
+   * Create Many entity in store
+   * @params payload Entities to create
+   */
+    createMany(payload: T[]): void {
+      payload.forEach(entity => this.createOne(entity))
+    },
+
+    /**
+     * set current used entity
+     * @param payload
+     */
+    setCurrent(payload: T) {
+      state.entities.current = { ...payload, $isDirty: false }
+    },
+
+    /**
+   * remove current used entity
+   * @param payload
+   */
+    removeCurrent() {
+      state.entities.current = null
+    },
+
+    /**
+     * Update One entiy in Store
+     * @param id of entity to update
+     * @param payload data of entity to update
+     */
+    updateOne(id: Id, payload: T): void {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id] = {
+          ...state.entities.byId[id],
+          ...payload,
+          $isDirty: true,
+        }
+      }
+      else {
+        this.createOne(payload)
+      }
+    },
+
+    /**
+     * Update many entities in Store
+     * @param ids of entities to update
+     * @param payload data of entity to update
+     */
+    updateMany(payload: T[]): void {
+      payload.forEach(entity => this.updateOne(entity.id, entity))
+    },
+
+    /**
+   * Delete one entity in Store
+   * @param id of entity to delete
+   */
+    deleteOne(id: Id) {
+      delete state.entities.byId[id]
+      state.entities.allIds = state.entities.allIds.filter(entityId => entityId !== id)
+      state.entities.active = state.entities.active.filter(entityId => entityId !== id)
+    },
+
+    /**
+   * delete many entities in Store
+   * @param ids of entities to delete
+   */
+    deleteMany(ids: Id[]) {
+      ids.forEach(id => this.deleteOne(id))
+    },
+
+    /**
+     * reset entities.active to an empty Array
+     */
+    resetActive() {
+      state.entities.active = []
+    },
+
+    /**
+   * set one entity as active with his id
+   * @param id of entity to set as active
+   */
+    setActive(id: Id) {
+      if (!state.entities.active.includes(id) && state.entities.byId[id])
+        state.entities.active.push(id)
+    },
+
+    /**
+   * set $isDirty property to true to know if the entity has been modified or not
+   * @param id of entity
+   */
+    setIsDirty(id: Id) {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id] = {
+          ...state.entities.byId[id]!,
+          $isDirty: true,
+        }
+      }
+    },
+
+    /**
+   * set $isDirty property to false to know if the entity has been modified or not
+   * @param id of entity
+   */
+    setIsNotDirty(id: Id) {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id] = {
+          ...state.entities.byId[id]!,
+          $isDirty: false,
+        }
+      }
+    },
+
+    /**
+     * update field of an entity
+     * @param field: string field to update
+     * @param id: Id of entity
+     */
+    updateField<K extends keyof T>(field: K, value: (T & { $isDirty: boolean })[K], id: Id) {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id]![field] = value
+        this.setIsDirty(id)
+      }
+    },
+
+    /**
+     * set currentById entity
+     * @param payload
+     */
+    setCurrentById(payload: Id) {
+      if (state.entities.byId[payload]) {
+        state.entities.currentById = payload
+      }
+    },
+
+    /**
+     * remove currentById entity
+     */
+    removeCurrentById() {
+      state.entities.currentById = null
+    },
+  }
+}

--- a/packages/core/src/createGetters.test.ts
+++ b/packages/core/src/createGetters.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { WithId } from '../types/WithId.js';
+import createGetters from './createGetters.js';
+import createState from './createState.js';
+
+// Test entity interface
+interface User extends WithId {
+  name: string;
+  email: string;
+  age: number;
+}
+
+type TemporaryState = ReturnType<typeof createState<User>> & ReturnType<typeof createGetters<User>>;
+
+describe('createGetters', () => {
+  let state: TemporaryState;
+
+  beforeEach(() => {
+    state = createState<User>() as TemporaryState;
+    state = {
+      ...state,
+      ...createGetters(state),
+    };
+    
+    // Add some test data
+    const user1: User & { $isDirty: boolean } = { id: 1, name: 'John', email: 'john@example.com', age: 30, $isDirty: false };
+    const user2: User & { $isDirty: boolean } = { id: 2, name: 'Jane', email: 'jane@example.com', age: 25, $isDirty: false };
+    const user3: User & { $isDirty: boolean } = { id: 3, name: 'Bob', email: 'bob@example.com', age: 35, $isDirty: true };
+    
+    state.entities.byId[1] = user1;
+    state.entities.byId[2] = user2;
+    state.entities.byId[3] = user3;
+    state.entities.allIds = [1, 2, 3];
+    state.entities.current = user1;
+    state.entities.currentById = 1;
+    state.entities.active = [1, 2];
+  });
+
+  describe('findOneById (deprecated)', () => {
+    test('should find entity by id', () => {
+      const findOne = state.findOneById();
+      const user = findOne(1);
+      
+      expect(user).toBeDefined();
+      expect(user?.name).toBe('John');
+      expect(user?.id).toBe(1);
+    });
+
+    test('should return undefined for non-existent id', () => {
+      const findOne = state.findOneById();
+      const user = findOne(999);
+      
+      expect(user).toBeUndefined();
+    });
+  });
+
+  describe('findManyById (deprecated)', () => {
+    test('should find multiple entities by ids', () => {
+      const findMany = state.findManyById();
+      const users = findMany([1, 2]);
+      
+      expect(users).toHaveLength(2);
+      expect(users[0]?.name).toBe('John');
+      expect(users[1]?.name).toBe('Jane');
+    });
+
+    test('should filter out non-existent ids', () => {
+      const findMany = state.findManyById();
+      const users = findMany([1, 999, 2]);
+      
+      expect(users).toHaveLength(2);
+      expect(users[0]?.name).toBe('John');
+      expect(users[1]?.name).toBe('Jane');
+    });
+
+    test('should return empty array for non-existent ids', () => {
+      const findMany = state.findManyById();
+      const users = findMany([999, 888]);
+      
+      expect(users).toHaveLength(0);
+    });
+  });
+
+  describe('getAll', () => {
+    test('should return all entities as dictionary', () => {
+      const all = state.getAll();
+      
+      expect(all).toBeDefined();
+      expect(Object.keys(all)).toHaveLength(3);
+      expect(all[1]?.name).toBe('John');
+      expect(all[2]?.name).toBe('Jane');
+      expect(all[3]?.name).toBe('Bob');
+    });
+
+    test('should return empty object for empty state', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      const all = emptyGetters.getAll();
+      
+      expect(all).toEqual({});
+    });
+  });
+
+  describe('getAllArray', () => {
+    test('should return all entities as array', () => {
+      const all = state.getAllArray();
+      
+      expect(Array.isArray(all)).toBe(true);
+      expect(all).toHaveLength(3);
+      expect(all.map(u => u.name)).toContain('John');
+      expect(all.map(u => u.name)).toContain('Jane');
+      expect(all.map(u => u.name)).toContain('Bob');
+    });
+
+    test('should return empty array for empty state', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      const all = emptyGetters.getAllArray();
+      
+      expect(all).toEqual([]);
+    });
+  });
+
+  describe('getAllIds', () => {
+    test('should return all entity ids', () => {
+      const ids = state.getAllIds();
+      
+      expect(Array.isArray(ids)).toBe(true);
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain(1);
+      expect(ids).toContain(2);
+      expect(ids).toContain(3);
+    });
+
+    test('should return empty array for empty state', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      const ids = emptyGetters.getAllIds();
+      
+      expect(ids).toEqual([]);
+    });
+  });
+
+  describe('getMissingIds', () => {
+    test('should return missing ids', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 4, 5]);
+      
+      expect(missing).toHaveLength(2);
+      expect(missing).toContain(4);
+      expect(missing).toContain(5);
+    });
+
+    test('should return empty array when all ids exist', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 3]);
+      
+      expect(missing).toHaveLength(0);
+    });
+
+    test('should handle duplicates when canHaveDuplicates is false', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 4, 4, 5], false);
+      
+      expect(missing).toHaveLength(2);
+      expect(missing).toContain(4);
+      expect(missing).toContain(5);
+    });
+
+    test('should handle duplicates when canHaveDuplicates is true', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 4, 4, 5], true);
+      
+      expect(missing).toHaveLength(3);
+      expect(missing).toContain(4);
+      expect(missing).toContain(4);
+      expect(missing).toContain(5);
+    });
+  });
+
+  describe('getMissingEntities', () => {
+    test('should return missing entities', () => {
+      const entities: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 4, name: 'Alice', email: 'alice@example.com', age: 28 },
+        { id: 5, name: 'Charlie', email: 'charlie@example.com', age: 32 }
+      ];
+      
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing(entities);
+      
+      expect(missing).toHaveLength(2);
+      expect(missing[0]?.name).toBe('Alice');
+      expect(missing[1]?.name).toBe('Charlie');
+    });
+
+    test('should return empty array when all entities exist', () => {
+      const entities: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing(entities);
+      
+      expect(missing).toHaveLength(0);
+    });
+
+    test('should handle empty array', () => {
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing([]);
+      
+      expect(missing).toEqual([]);
+    });
+
+    test('should handle null/undefined array', () => {
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing(null as any);
+      
+      expect(missing).toEqual([]);
+    });
+  });
+
+  describe('getWhere', () => {
+    test('should filter entities by predicate', () => {
+      const getWhere = state.getWhere();
+      const adults = getWhere(user => user.age >= 30);
+      
+      expect(Object.keys(adults)).toHaveLength(2);
+      expect(adults[1]?.name).toBe('John');
+      expect(adults[3]?.name).toBe('Bob');
+    });
+
+    test('should return all entities when filter is not a function', () => {
+      const getWhere = state.getWhere();
+      const all = getWhere(null as any);
+      
+      expect(Object.keys(all)).toHaveLength(3);
+    });
+
+    test('should return empty object when no entities match filter', () => {
+      const getWhere = state.getWhere();
+      const seniors = getWhere(user => user.age >= 60);
+      
+      expect(Object.keys(seniors)).toHaveLength(0);
+    });
+  });
+
+  describe('getWhereArray', () => {
+    test('should filter entities by predicate and return array', () => {
+      const getWhereArray = state.getWhereArray();
+      const adults = getWhereArray(user => user.age >= 30);
+      
+      expect(Array.isArray(adults)).toBe(true);
+      expect(adults).toHaveLength(2);
+      expect(adults.map(u => u.name)).toContain('John');
+      expect(adults.map(u => u.name)).toContain('Bob');
+    });
+
+    test('should return all entities when filter is not a function', () => {
+      const getWhereArray = state.getWhereArray();
+      const all = getWhereArray(null as any);
+      
+      expect(Array.isArray(all)).toBe(true);
+      expect(all).toHaveLength(3);
+    });
+
+    test('should return empty array when no entities match filter', () => {
+      const getWhereArray = state.getWhereArray();
+      const seniors = getWhereArray(user => user.age >= 60);
+      
+      expect(Array.isArray(seniors)).toBe(true);
+      expect(seniors).toHaveLength(0);
+    });
+  });
+
+  describe('getCurrent', () => {
+    test('should return current entity', () => {
+      const current = state.getCurrent();
+      
+      expect(current).toBeDefined();
+      expect(current?.name).toBe('John');
+      expect(current?.id).toBe(1);
+    });
+
+    test('should return null when no current entity', () => {
+      state.entities.current = null;
+      const current = state.getCurrent();
+      
+      expect(current).toBeNull();
+    });
+  });
+
+  describe('getCurrentById', () => {
+    test('should return current entity', () => {
+      const currentEntity = state.getCurrentById();
+      
+      expect(currentEntity).toBeDefined();
+      expect(currentEntity?.id).toBe(1);
+      expect(currentEntity?.name).toBe('John');
+    });
+
+    test('should return null when no current entity', () => {
+      state.entities.currentById = null;
+      const currentId = state.getCurrentById();
+      
+      expect(currentId).toBeNull();
+    });
+  });
+
+  describe('getActive', () => {
+    test('should return active entities', () => {
+      const active = state.getActive();
+      
+      expect(Array.isArray(active)).toBe(true);
+      expect(active).toHaveLength(2);
+      expect(active).toContain(1);
+      expect(active).toContain(2);
+    });
+
+    test('should return empty array when no active entities', () => {
+      state.entities.active = [];
+      const active = state.getActive();
+      
+      expect(active).toEqual([]);
+    });
+  });
+
+  describe('getFirstActive', () => {
+    test('should return first active entity', () => {
+      const first = state.getFirstActive();
+      
+      expect(first).toBeDefined();
+      expect(first).toBe(1);
+    });
+
+    test('should return undefined when no active entities', () => {
+      state.entities.active = [];
+      const first = state.getFirstActive();
+      
+      expect(first).toBeUndefined();
+    });
+  });
+
+  describe('isAlreadyInStore', () => {
+    test('should return true for existing entity', () => {
+      const isInStore = state.isAlreadyInStore();
+      expect(isInStore(1)).toBe(true);
+      expect(isInStore(2)).toBe(true);
+      expect(isInStore(3)).toBe(true);
+    });
+
+    test('should return false for non-existent entity', () => {
+      const isInStore = state.isAlreadyInStore();
+      expect(isInStore(999)).toBe(false);
+    });
+  });
+
+  describe('isAlreadyActive', () => {
+    test('should return true for active entity', () => {
+      const isActive = state.isAlreadyActive();
+      expect(isActive(1)).toBe(true);
+      expect(isActive(2)).toBe(true);
+    });
+
+    test('should return false for non-active entity', () => {
+      const isActive = state.isAlreadyActive();
+      expect(isActive(3)).toBe(false);
+    });
+
+    test('should return false for non-existent entity', () => {
+      const isActive = state.isAlreadyActive();
+      expect(isActive(999)).toBe(false);
+    });
+  });
+
+  describe('isDirty', () => {
+    test('should return dirty status of entity', () => {
+      const isDirty = state.isDirty();
+      expect(isDirty(1)).toBe(false);
+      expect(isDirty(2)).toBe(false);
+      expect(isDirty(3)).toBe(true);
+    });
+
+    test('should return false for non-existent entity', () => {
+      const isDirty = state.isDirty();
+      expect(isDirty(999)).toBe(false);
+    });
+  });
+
+  describe('isEmpty', () => {
+    test('should return false when entities exist', () => {
+      expect(state.getIsEmpty()).toBe(false);
+    });
+
+    test('should return true when no entities exist', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      
+      expect(emptyGetters.getIsEmpty()).toBe(true);
+    });
+  });
+
+  describe('isNotEmpty', () => {
+    test('should return true when entities exist', () => {
+      expect(state.getIsNotEmpty()).toBe(true);
+    });
+
+    test('should return false when no entities exist', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      
+      expect(emptyGetters.getIsNotEmpty()).toBe(false);
+    });
+  });
+});
+

--- a/packages/core/src/createGetters.ts
+++ b/packages/core/src/createGetters.ts
@@ -1,0 +1,261 @@
+
+import type { State } from './types/State.js'
+import type { Id, WithId } from './types/WithId.js'
+
+export default function createGetters<T extends WithId>(currentState: State<T>) {
+  /**
+   * Get a single item from the state by its id.
+   * @param id - The id of the item
+   * @Deprecated use getOne
+   */
+  function findOneById(state = currentState) {
+    return (id: Id) => state.entities.byId[id]
+  }
+
+  /**
+   * Get multiple items from the state by their ids.
+   * @param ids - The ids of items
+   * @Deprecated use getMany
+   */
+  function findManyById(state = currentState) {
+    return (ids: Id[]) => ids.map(id => state.entities.byId[id]).filter(id => id)
+  }
+
+  /**
+   * Get all the items from the state as a dictionnary of values.
+   */
+  function getAll(state = currentState) {
+    return state.entities.byId
+  }
+
+  /**
+   * Get all items from the state as an array of values.
+   */
+  function getAllArray(state = currentState) {
+    return Object.values(state.entities.byId)
+  }
+
+  /**
+   * Get an array containing the ids of all the items in the state.
+   */
+  function getAllIds(state = currentState) {
+    return state.entities.allIds
+  }
+
+  /**
+   * @param ids Id[]
+   * @param canHaveDuplicates boolean not required
+   * @returns returns a list of missing IDs in the store compared to the ids passed to the getter. with an option to filter out duplicates
+   */
+  function getMissingIds(state = currentState) {
+    return (ids: Id[], canHaveDuplicates?: boolean) => {
+      const filteredIds = ids.filter(id => !state.entities.allIds.includes(id))
+      if (!canHaveDuplicates)
+        return Array.from(new Set(filteredIds))
+
+      return filteredIds
+    }
+  }
+
+  /**
+  * @param entitiesArray T[]
+  * @returns returns a list of missing entities in the store
+  */
+  function getMissingEntities(state = currentState) {
+    return (entitiesArray: T[]) => {
+      if (entitiesArray?.length > 0)
+        return entitiesArray.filter(entity => !state.entities.allIds.includes(entity.id))
+
+      return []
+    }
+  }
+
+  /**
+   * Get all the items that pass the given filter callback as a dictionnary of values.
+   * @param filter - The filtering callback that will be used to filter the items.
+   */
+  function getWhere(state = currentState) {
+    return (filter: (arg: T & { $isDirty: boolean }) => boolean | null) => {
+      if (typeof filter !== 'function')
+        return state.entities.byId
+
+      return state.entities.allIds.reduce((acc: Record<Id, T & { $isDirty: boolean }>, id: Id) => {
+        const item = state.entities.byId[id]
+        if (!item || !filter(item))
+          return acc
+
+        acc[id] = item
+        return acc
+      }, {} as Record<Id, T & { $isDirty: boolean }>)
+    }
+  }
+
+  /**
+   * Get all the items that pass the given filter callback as an array of values.
+   * @param filter - The filtering callback that will be used to filter the items.
+   */
+  function getWhereArray(state = currentState) {
+    return (filter: (arg: T & { $isDirty: boolean }) => boolean | null) => {
+      if (typeof filter !== 'function')
+        return Object.values(state.entities.byId)
+
+      return Object.values(state.entities.allIds.reduce((acc: Record<Id, T & { $isDirty: boolean }>, id: Id) => {
+        const item = state.entities.byId[id]
+        if (!item || !filter(item))
+          return acc
+
+        acc[id] = item
+        return acc
+      }, {} as Record<Id, T & { $isDirty: boolean }>))
+    }
+  }
+
+  /**
+   * Get the first item that passes the given filter callback.
+   * @param filter - The filtering callback that will be used to filter the items.
+   * @returns The first item that passes the filter, or the first item in the state if no filter is provided.
+   */
+  function getFirstWhere(state = currentState) {
+    return (filter: (arg: T & { $isDirty: boolean }) => boolean | null) => {
+      if (typeof filter !== 'function')
+        return Object.values(state.entities.byId)[0]
+
+      return Object.values(state.entities.allIds.reduce((acc: Record<Id, T & { $isDirty: boolean }>, id: Id) => {
+        const item = state.entities.byId[id]
+        if (!item || !filter(item))
+          return acc
+
+        acc[id] = item
+        return acc
+      }, {} as Record<Id, T & { $isDirty: boolean }>))[0]
+    }
+  }
+
+  /**
+   * Returns a boolean indicating wether or not the state is empty (contains no items).
+   */
+  function getIsEmpty(state = currentState) {
+    return state.entities.allIds.length === 0
+  }
+
+  /**
+   * Returns a boolean indicating wether or not the state is not empty (contains items).
+  */
+  function getIsNotEmpty(state = currentState) {
+    return state.entities.allIds.length > 0
+  }
+
+  /**
+   * @return current entity stored in state
+   */
+  function getCurrent(state = currentState) {
+    return state.entities.current
+  }
+
+  /**
+   * Get a single item from the state by its id.
+   * @param id - The id of the item
+   */
+  function getOne(state = currentState) {
+    return (id: Id) => state.entities.byId[id]
+  }
+
+  /**
+   * Get a array of items from the state by their ids.
+   * @param ids - ids of items
+   */
+  function getMany(state = currentState) {
+    return (ids: Id[]) => ids.map(id => state.entities.byId[id]).filter((item): item is T & { $isDirty: boolean } => item !== undefined)
+  }
+
+  /**
+   *  @return array of active entities stored in state
+   */
+  function getActive(state = currentState) {
+    return state.entities.active
+  }
+
+  /**
+   *  @return first entity get from array of active entities stored in state
+   */
+  function getFirstActive(state = currentState) {
+    return state.entities.active[0]
+  }
+
+  /**
+   * helper to determine if the entity is already stored in state
+   * @param id - The id of the item
+   *  @return boolean
+   */
+  function isAlreadyInStore(state = currentState) {
+    return (id: Id) => state.entities.allIds.includes(id)
+  }
+
+  /**
+   * helper to determine if the entity is already set as Active in state
+   * @param id - The id of the item
+   *  @return boolean
+   */
+  function isAlreadyActive(state = currentState) {
+    return (id: Id) => state.entities.active.includes(id)
+  }
+
+  /**
+   * helper to know if an entity has been modified
+   *  @param id - The id of the item
+   *  @return boolean
+   */
+  function isDirty(state = currentState) {
+    return (id: Id) => state.entities.byId[id]?.$isDirty || false
+  }
+
+  /**
+   * Search for an entity in the state
+   * @param field - The field to search for
+   * @return array of entities
+   */
+  function search(state = currentState) {
+    return (field: string) => Object.values(state.entities.byId)
+      .filter(item => {
+        const regex = new RegExp(field, 'i')
+        for (const value of Object.values(item)) {
+          if (typeof value === 'string' && regex.test(value)) {
+            return true
+          }
+        }
+        return false
+      })
+  }
+
+  /**
+   * Get currentById entity stored in state
+   */
+  function getCurrentById(state = currentState) {
+    return state.entities.currentById ? state.entities.byId[state.entities.currentById] : null
+  }
+
+  return {
+    findManyById,
+    findOneById,
+    getActive,
+    getAll,
+    getAllArray,
+    getAllIds,
+    getCurrent,
+    getFirstActive,
+    getFirstWhere,
+    getIsEmpty,
+    getIsNotEmpty,
+    getMany,
+    getMissingEntities,
+    getMissingIds,
+    getOne,
+    getWhere,
+    getWhereArray,
+    isAlreadyActive,
+    isAlreadyInStore,
+    isDirty,
+    search,
+    getCurrentById,
+  }
+}

--- a/packages/core/src/createState.test.ts
+++ b/packages/core/src/createState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import type { WithId } from '../types/WithId.js';
+import createState from './createState.js';
+
+// Test entity interface
+interface User extends WithId {
+  name: string;
+  email: string;
+  age: number;
+}
+
+describe('createState', () => {
+  test('should create initial state with correct structure', () => {
+    const state = createState<User>();
+    
+    expect(state).toBeDefined();
+    expect(state.entities).toBeDefined();
+    expect(state.entities.byId).toEqual({});
+    expect(state.entities.allIds).toEqual([]);
+    expect(state.entities.current).toBeNull();
+    expect(state.entities.currentById).toBeNull();
+    expect(state.entities.active).toEqual([]);
+  });
+
+  test('should create state with correct types', () => {
+    const state = createState<User>();
+    
+    // Test that byId is a Record with Id keys and User & { $isDirty: boolean } values
+    expect(typeof state.entities.byId).toBe('object');
+    expect(Array.isArray(state.entities.byId)).toBe(false);
+    
+    // Test that allIds is an array
+    expect(Array.isArray(state.entities.allIds)).toBe(true);
+    
+    // Test that current can be null
+    expect(state.entities.current).toBeNull();
+    
+    // Test that currentById can be null
+    expect(state.entities.currentById).toBeNull();
+    
+    // Test that active is an array
+    expect(Array.isArray(state.entities.active)).toBe(true);
+  });
+
+  test('should create independent state instances', () => {
+    const state1 = createState<User>();
+    const state2 = createState<User>();
+    
+    // States should be different objects
+    expect(state1).not.toBe(state2);
+    expect(state1.entities).not.toBe(state2.entities);
+    expect(state1.entities.byId).not.toBe(state2.entities.byId);
+    expect(state1.entities.allIds).not.toBe(state2.entities.allIds);
+    expect(state1.entities.active).not.toBe(state2.entities.active);
+  });
+
+  test('should work with different entity types', () => {
+    interface Product extends WithId {
+      name: string;
+      price: number;
+    }
+    
+    const userState = createState<User>();
+    const productState = createState<Product>();
+    
+    expect(userState.entities.byId).toEqual({});
+    expect(productState.entities.byId).toEqual({});
+    
+    // Both should have the same structure but be different instances
+    expect(userState).not.toBe(productState);
+  });
+});

--- a/packages/core/src/createState.ts
+++ b/packages/core/src/createState.ts
@@ -1,0 +1,14 @@
+import type { State } from './types/State.js'
+import type { WithId } from './types/WithId.js'
+
+export default function<T extends WithId>(): State<T & { $isDirty: boolean }> {
+  return {
+    entities: {
+      byId: {},
+      allIds: [],
+      current: null,
+      currentById: null,
+      active: [],
+    },
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,5 @@
+// Core package index file
+export { default as createActions } from './createActions.js';
+export { default as createGetters } from './createGetters.js';
+export { default as createState } from './createState.js';
+

--- a/packages/core/src/types/ByIdParams.ts
+++ b/packages/core/src/types/ByIdParams.ts
@@ -1,0 +1,6 @@
+import type { Id } from './WithId'
+
+export interface ByIdParams<T> {
+  id: Id
+  payload: T
+}

--- a/packages/core/src/types/Filter.ts
+++ b/packages/core/src/types/Filter.ts
@@ -1,0 +1,3 @@
+export type FilterFn<T> = (item: T) => boolean | null
+
+export type OptionalFilterFn<T> = FilterFn<T> | null

--- a/packages/core/src/types/State.ts
+++ b/packages/core/src/types/State.ts
@@ -1,0 +1,13 @@
+import type { Id, WithId } from './WithId'
+
+export interface State<T extends WithId> {
+  entities: {
+    byId: Record<Id, T & { $isDirty: boolean }>
+    allIds: Id[]
+    current: T & { $isDirty: boolean } | null
+    currentById: Id | null
+    active: Id[]
+  }
+}
+
+// export type CreatedEntity<T> = T & { $isDirty: boolean }

--- a/packages/core/src/types/WithId.ts
+++ b/packages/core/src/types/WithId.ts
@@ -1,0 +1,5 @@
+export interface WithId {
+  id: Id
+}
+
+export type Id = number | string

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,0 +1,5 @@
+// Types package index file
+export type { Id, WithId } from './WithId.js';
+export type { State } from './State.js';
+export type { FilterFn, OptionalFilterFn } from './Filter.js';
+export type { ByIdParams } from './ByIdParams.js';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "entity-store",
+  "version": "1.0.0",
+  "description": "ORM agnostique avec des adaptateurs pour différents state managers",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./core": {
+      "types": "../core/dist/index.d.ts",
+      "import": "../core/dist/index.js"
+    },
+    "./types": {
+      "types": "../types/dist/index.d.ts",
+      "import": "../types/dist/index.js"
+    },
+    "./pinia": {
+      "types": "../pinia-adapter/dist/index.d.ts",
+      "import": "../pinia-adapter/dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "pnpm -r build",
+    "dev": "pnpm -r dev",
+    "test": "pnpm -r test",
+    "clean": "pnpm -r clean",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "keywords": [
+    "orm",
+    "state-management",
+    "typescript",
+    "agnostic",
+    "entity-store",
+    "pinia",
+    "zustand",
+    "redux"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@entity-store/core": "workspace:*",
+    "@entity-store/types": "workspace:*",
+    "@entity-store/pinia-adapter": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -1,0 +1,14 @@
+// Main export file for the entity-store package
+
+// Re-export types and interfaces
+export type { ByIdParams, FilterFn, Id, OptionalFilterFn, State, WithId } from '@entity-store/types';
+
+// Re-export core functions
+export { default as createActions, default as createGetters, default as createState } from '@entity-store/core';
+
+// Re-export adapters
+export { createPiniaEntityStore } from '@entity-store/pinia-adapter';
+export type { BaseEntityStore, PiniaEntityStore, PiniaEntityStoreOptions } from '@entity-store/pinia-adapter';
+
+// Utilities (coming soon)
+// export * from './utils/index.js';

--- a/packages/main/tsconfig.json
+++ b/packages/main/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/packages/pinia-adapter/README.md
+++ b/packages/pinia-adapter/README.md
@@ -1,0 +1,231 @@
+# @entity-store/pinia-adapter
+
+Pinia adapter for entity-store, enabling entity management with Pinia.
+
+## Installation
+
+```bash
+npm install @entity-store/pinia-adapter pinia
+# or
+pnpm add @entity-store/pinia-adapter pinia
+# or
+yarn add @entity-store/pinia-adapter pinia
+```
+
+**Note**: `pinia` is a peer dependency, you must install it separately.
+
+## Usage
+
+### Basic import
+
+```typescript
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+import type { WithId } from '@entity-store/types'
+```
+
+### Create a store
+
+```typescript
+interface User extends WithId {
+  name: string
+  email: string
+  age: number
+}
+
+// Create a simple store
+const useUserStore = createPiniaEntityStore<User>('users')
+
+// Use the store
+const userStore = useUserStore()
+```
+
+### Available features
+
+The created store automatically contains:
+
+#### **State**
+- `entities.byId` : Record of entities by ID
+- `entities.allIds` : List of IDs
+- `entities.current` : Currently selected entity
+- `entities.currentById` : ID of current entity
+- `entities.active` : List of active IDs
+
+#### **Actions**
+- `createOne(user)` : Create an entity
+- `createMany(users)` : Create multiple entities
+- `updateOne(id, user)` : Update an entity
+- `updateMany(users)` : Update multiple entities
+- `deleteOne(id)` : Delete an entity
+- `deleteMany(ids)` : Delete multiple entities
+- `setCurrent(user)` : Set current entity
+- `setCurrentById(id)` : Set current entity by ID
+- `setActive(id)` : Mark entity as active
+- `resetActive()` : Reset active entities
+- `setIsDirty(id)` : Mark entity as modified
+- `setIsNotDirty(id)` : Mark entity as unmodified
+- `updateField(field, value, id)` : Update a specific field
+
+#### **Getters**
+- `getOne()(id)` : Get entity by ID
+- `getMany(ids)` : Get multiple entities by IDs
+- `getAll()` : Get all entities
+- `getAllArray()` : Get all entities as array
+- `getAllIds()` : Get all IDs
+- `getCurrent()` : Get current entity
+- `getCurrentById()` : Get current entity by ID
+- `getActive()` : Get active entities
+- `getFirstActive()` : Get first active entity
+- `getWhere(filter)` : Filter entities
+- `getWhereArray(filter)` : Filter entities as array
+- `getFirstWhere(filter)` : Get first filtered entity
+- `getIsEmpty()` : Check if state is empty
+- `getIsNotEmpty()` : Check if state is not empty
+- `isAlreadyInStore(id)` : Check if entity exists
+- `isAlreadyActive(id)` : Check if entity is active
+- `isDirty(id)` : Check if entity is modified
+- `search(field)` : Search in entities
+- `getMissingIds(ids)` : Get missing IDs
+- `getMissingEntities(entities)` : Get missing entities
+
+## Usage Examples
+
+### Simple store
+
+```typescript
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+import type { WithId } from '@entity-store/types'
+
+interface User extends WithId {
+  name: string
+  email: string
+}
+
+const useUserStore = createPiniaEntityStore<User>('users')
+
+// In a Vue component
+export default {
+  setup() {
+    const userStore = useUserStore()
+    
+    // Create users
+    const user: User = { id: 1, name: 'John', email: 'john@example.com' }
+    userStore.createOne(user)
+    
+    // Set current user
+    userStore.setCurrent(user)
+    
+    // Get data
+    const currentUser = userStore.getCurrent()
+    const allUsers = userStore.getAllArray()
+    
+    return {
+      userStore,
+      currentUser,
+      allUsers
+    }
+  }
+}
+```
+
+### Store with extensions
+
+```typescript
+const useUserStore = createPiniaEntityStore<User>('users', {
+  // Custom state
+  state: {
+    isLoading: false,
+    error: null
+  },
+  
+  // Custom getters
+  getters: {
+    getUsersByAge: (store) => (minAge: number) => {
+      return store.getAllArray().filter(user => user.age >= minAge)
+    },
+    
+    getActiveUsersCount: (store) => () => {
+      return store.getActive().length
+    }
+  },
+  
+  // Custom actions
+  actions: {
+    async fetchUsers: (store) => async () => {
+      store.$patch({ isLoading: true, error: null })
+      
+      try {
+        const users = await api.getUsers()
+        store.createMany(users)
+      } catch (error) {
+        store.$patch({ error: error.message })
+      } finally {
+        store.$patch({ isLoading: false })
+      }
+    }
+  }
+})
+```
+
+### Usage with Composition API
+
+```typescript
+import { useUserStore } from '@/stores/users'
+import { storeToRefs } from 'pinia'
+
+export default {
+  setup() {
+    const userStore = useUserStore()
+    
+    // Destructure with storeToRefs for reactivity
+    const { entities, isLoading, error } = storeToRefs(userStore)
+    
+    // Actions remain functions
+    const { createOne, setCurrent, fetchUsers } = userStore
+    
+    return {
+      entities,
+      isLoading,
+      error,
+      createOne,
+      setCurrent,
+      fetchUsers
+    }
+  }
+}
+```
+
+## Advanced Configuration
+
+### Store options
+
+```typescript
+interface PiniaEntityStoreOptions<T extends WithId> {
+  state?: Record<string, unknown>           // Additional state
+  getters?: Record<string, (store: BaseEntityStore<T>) => (...args: unknown[]) => unknown>
+  actions?: Record<string, (store: BaseEntityStore<T>) => (...args: unknown[]) => unknown>
+  storeName?: string                        // Custom store name
+}
+```
+
+### Available types
+
+```typescript
+import type { 
+  PiniaEntityStore, 
+  BaseEntityStore, 
+  PiniaEntityStoreOptions 
+} from '@entity-store/pinia-adapter'
+
+// PiniaEntityStore<T> : Complete store type
+// BaseEntityStore<T> : Base type with entities
+// PiniaEntityStoreOptions<T> : Configuration options
+```
+
+## Benefits
+
+- **Native integration**: Uses standard Pinia API
+- **Type-safe**: Fully typed with TypeScript
+- **Flexible**: Easily extensible with custom features
+- **Performant**: Uses Pinia reactivity
+- **Compatible**: Works with Vue 2 (Pinia) and Vue 3
+- **Tested**: Complete test coverage

--- a/packages/pinia-adapter/package.json
+++ b/packages/pinia-adapter/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@entity-store/pinia-adapter",
+  "version": "1.0.0",
+  "description": "Pinia adapter for entity-store",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest --coverage",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "keywords": [
+    "pinia",
+    "entity-management",
+    "state-management",
+    "vue"
+  ],
+  "author": "",
+  "license": "MIT",
+  "peerDependencies": {
+    "pinia": "^3.0.0"
+  },
+  "dependencies": {
+    "@entity-store/core": "workspace:*",
+    "@entity-store/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "@vitest/coverage-v8": "^3.2.4",
+    "pinia": "^3.0.3",
+    "typescript": "^5.9.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/pinia-adapter/src/README.md
+++ b/packages/pinia-adapter/src/README.md
@@ -1,0 +1,470 @@
+# Pinia Entity Store Adapter
+
+Un adaptateur Pinia pour le système de gestion d'entités agnostique, permettant de créer des stores avec gestion complète des entités tout en conservant la flexibilité de Pinia.
+
+## 📦 Installation
+
+```bash
+pnpm add entity-store
+```
+
+## 🚀 Utilisation de base
+
+```typescript
+import { createPiniaEntityStore } from 'entity-store/adapters/pinia'
+
+interface Todo {
+  id: number
+  title: string
+  completed: boolean
+}
+
+// Créer un store basique
+export const useTodoStore = createPiniaEntityStore<Todo>('todos')
+```
+
+## ✨ Fonctionnalités
+
+### Gestion automatique des entités
+
+Le store inclut automatiquement toutes les méthodes de gestion d'entités :
+
+- **Getters** : `getOne`, `getAll`, `getAllArray`, `getAllIds`, `getCurrent`, `getActive`, etc.
+- **Actions** : `createOne`, `createMany`, `updateOne`, `deleteOne`, `setCurrent`, `setActive`, etc.
+- **État** : `byId`, `allIds`, `current`, `currentById`, `active`, `$isDirty`
+
+### Extension avec des getters personnalisés
+
+```typescript
+export const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+  getters: {
+    // Getter personnalisé : obtenir les todos par priorité
+    getTodosByPriority: (store) => (priority: 'low' | 'medium' | 'high') => {
+      const getWhere = store.getWhere()
+      return getWhere(todo => todo.priority === priority)
+    },
+    
+    // Getter personnalisé : compter les todos complétés
+    getCompletedCount: (store) => () => {
+      const getWhere = store.getWhere()
+      return Object.keys(getWhere(todo => todo.completed)).length
+    }
+  }
+})
+```
+
+### Extension avec des actions personnalisées
+
+```typescript
+export const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+  actions: {
+    // Action personnalisée : basculer la completion d'un todo
+    toggleTodo: (store) => (id: number) => {
+      const current = store.getOne()(id)
+      if (current) {
+        const updatedTodo = {
+          ...current,
+          completed: !current.completed,
+          updatedAt: new Date()
+        }
+        store.updateOne(id, updatedTodo)
+      }
+    },
+    
+    // Action personnalisée : compléter tous les todos
+    completeAll: (store) => () => {
+      const allTodos = store.getAllArray()
+      allTodos.forEach(todo => {
+        if (!todo.completed) {
+          store.updateOne(todo.id, { ...todo, completed: true })
+        }
+      })
+    }
+  }
+})
+```
+
+### Extension avec un état personnalisé
+
+```typescript
+export const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+  state: {
+    // État UI personnalisé
+    ui: {
+      isLoading: false,
+      error: null as string | null
+    },
+    
+    // Filtres personnalisés
+    filters: {
+      showCompleted: true,
+      priorityFilter: null as 'low' | 'medium' | 'high' | null
+    }
+  }
+})
+```
+
+### Extension complète (état + getters + actions)
+
+```typescript
+export const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+  state: {
+    ui: { 
+      isLoading: false, 
+      error: null as string | null,
+      selectedTags: [] as string[],
+      sortBy: 'createdAt' as 'createdAt' | 'updatedAt' | 'priority' | 'title',
+      sortOrder: 'desc' as 'asc' | 'desc'
+    },
+    filters: { 
+      showCompleted: true, 
+      showIncomplete: true,
+      priorityFilter: null as 'low' | 'medium' | 'high' | null,
+      tagFilter: null as string | null
+    }
+  },
+  
+  getters: {
+    // Getter personnalisé : obtenir les todos filtrés et triés
+    getFilteredTodos: (store) => () => {
+      let todos = store.getAllArray()
+      
+      // Appliquer les filtres
+      if (!store.entities.filters.showCompleted) {
+        todos = todos.filter(todo => !todo.completed)
+      }
+      if (!store.entities.filters.showIncomplete) {
+        todos = todos.filter(todo => todo.completed)
+      }
+      if (store.entities.filters.priorityFilter) {
+        todos = todos.filter(todo => todo.priority === store.entities.filters.priorityFilter)
+      }
+      if (store.entities.filters.tagFilter) {
+        todos = todos.filter(todo => todo.tags.includes(store.entities.filters.tagFilter!))
+      }
+      
+      // Appliquer le tri
+      todos.sort((a, b) => {
+        let aValue: any
+        let bValue: any
+        
+        switch (store.entities.ui.sortBy) {
+          case 'createdAt':
+            aValue = a.createdAt.getTime()
+            bValue = b.createdAt.getTime()
+            break
+          case 'updatedAt':
+            aValue = a.updatedAt.getTime()
+            bValue = b.updatedAt.getTime()
+            break
+          case 'priority':
+            const priorityOrder = { high: 3, medium: 2, low: 1 }
+            aValue = priorityOrder[a.priority]
+            bValue = priorityOrder[b.priority]
+            break
+          case 'title':
+            aValue = a.title.toLowerCase()
+            bValue = b.title.toLowerCase()
+            break
+          default:
+            return 0
+        }
+        
+        if (store.entities.ui.sortOrder === 'asc') {
+          return aValue > bValue ? 1 : -1
+        } else {
+          return aValue < bValue ? 1 : -1
+        }
+      })
+      
+      return todos
+    },
+    
+    // Getter personnalisé : obtenir tous les tags disponibles
+    getAvailableTags: (store) => () => {
+      const allTags = new Set<string>()
+      store.getAllArray().forEach(todo => {
+        todo.tags.forEach(tag => allTags.add(tag))
+      })
+      return Array.from(allTags).sort()
+    }
+  },
+  
+  actions: {
+    // Actions personnalisées pour l'UI
+    setLoading: (store) => (loading: boolean) => {
+      store.entities.ui.isLoading = loading
+    },
+    
+    setError: (store) => (error: string | null) => {
+      store.entities.ui.error = error
+    },
+    
+    setSortBy: (store) => (sortBy: 'createdAt' | 'updatedAt' | 'priority' | 'title') => {
+      store.entities.ui.sortBy = sortBy
+    },
+    
+    setSortOrder: (store) => (sortOrder: 'asc' | 'desc') => {
+      store.entities.ui.sortOrder = sortOrder
+    },
+    
+    // Actions personnalisées pour les filtres
+    toggleFilter: (store) => (filterType: keyof typeof store.entities.filters) => {
+      if (filterType === 'showCompleted' || filterType === 'showIncomplete') {
+        store.entities.filters[filterType] = !store.entities.filters[filterType]
+      }
+    },
+    
+    setPriorityFilter: (store) => (priority: 'low' | 'medium' | 'high' | null) => {
+      store.entities.filters.priorityFilter = priority
+    },
+    
+    setTagFilter: (store) => (tag: string | null) => {
+      store.entities.filters.tagFilter = tag
+    },
+    
+    clearFilters: (store) => () => {
+      store.entities.filters.showCompleted = true
+      store.entities.filters.showIncomplete = true
+      store.entities.filters.priorityFilter = null
+      store.entities.filters.tagFilter = null
+    }
+  }
+})
+```
+
+## 🎯 Utilisation dans un composant Vue
+
+```vue
+<template>
+  <div>
+    <!-- État UI -->
+    <div v-if="todoStore.entities.ui.isLoading">Chargement...</div>
+    <div v-if="todoStore.entities.ui.error" class="error">{{ todoStore.entities.ui.error }}</div>
+    
+    <!-- Contrôles de tri -->
+    <select v-model="todoStore.entities.ui.sortBy">
+      <option value="createdAt">Date de création</option>
+      <option value="updatedAt">Date de modification</option>
+      <option value="priority">Priorité</option>
+      <option value="title">Titre</option>
+    </select>
+    
+    <button @click="todoStore.setSortOrder(todoStore.entities.ui.sortOrder === 'asc' ? 'desc' : 'asc')">
+      {{ todoStore.entities.ui.sortOrder === 'asc' ? '↑' : '↓' }}
+    </button>
+    
+    <!-- Filtres -->
+    <label>
+      <input 
+        type="checkbox" 
+        v-model="todoStore.entities.filters.showCompleted"
+        @change="todoStore.toggleFilter('showCompleted')"
+      />
+      Afficher les complétés
+    </label>
+    
+    <select v-model="todoStore.entities.filters.priorityFilter">
+      <option value="">Toutes les priorités</option>
+      <option value="high">Haute</option>
+      <option value="medium">Moyenne</option>
+      <option value="low">Basse</option>
+    </select>
+    
+    <button @click="todoStore.clearFilters()">Réinitialiser les filtres</button>
+    
+    <!-- Liste des todos -->
+    <div v-for="todo in filteredTodos" :key="todo.id">
+      <input 
+        type="checkbox" 
+        :checked="todo.completed"
+        @change="todoStore.toggleTodo(todo.id)"
+      />
+      {{ todo.title }}
+      <span :class="`priority-${todo.priority}`">{{ todo.priority }}</span>
+      
+      <!-- Tags -->
+      <div v-for="tag in todo.tags" :key="tag">
+        {{ tag }}
+        <button @click="todoStore.removeTag(todo.id, tag)">×</button>
+      </div>
+      
+      <button @click="addTag(todo.id)">+ Tag</button>
+    </div>
+    
+    <!-- Actions en lot -->
+    <button @click="todoStore.completeAll()">Tout compléter</button>
+    
+    <!-- Statistiques -->
+    <div>
+      Total: {{ todoStore.getAllIds().length }} |
+      Complétés: {{ todoStore.getCompletedCount() }} |
+      Haute priorité: {{ Object.keys(todoStore.getHighPriorityTodos()).length }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useTodoStore } from './stores/todoStore'
+
+const todoStore = useTodoStore()
+
+// Utiliser le getter personnalisé
+const filteredTodos = computed(() => todoStore.getFilteredTodos())
+
+// Fonction pour ajouter un tag
+const addTag = (id: number) => {
+  const tag = prompt('Entrez un tag:')
+  if (tag) {
+    todoStore.addTag(id, tag)
+  }
+}
+
+// Initialiser avec des données d'exemple
+const initializeStore = () => {
+  if (todoStore.getIsEmpty()) {
+    const sampleTodos = [
+      { 
+        id: 1, 
+        title: 'Apprendre Vue 3', 
+        description: 'Maîtriser la Composition API', 
+        completed: false, 
+        priority: 'high' as const, 
+        tags: ['vue', 'learning'],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      { 
+        id: 2, 
+        title: 'Construire Entity Store', 
+        description: 'Créer un système robuste', 
+        completed: false, 
+        priority: 'high' as const, 
+        tags: ['architecture', 'typescript'],
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]
+    
+    todoStore.createMany(sampleTodos)
+  }
+}
+
+// Initialiser au montage
+onMounted(() => {
+  initializeStore()
+})
+</script>
+```
+
+## 🔧 Améliorations de typage TypeScript
+
+L'adaptateur utilise maintenant des types Pinia natifs au lieu de `any`, offrant une meilleure sécurité des types :
+
+### Types exportés
+
+```typescript
+import { 
+  createPiniaEntityStore, 
+  type BaseEntityStore,
+  type PiniaEntityStore 
+} from 'entity-store/adapters/pinia'
+
+// BaseEntityStore<T> - Type de base avec toutes les méthodes d'entités
+// PiniaEntityStore<T> - Type du store instancié
+```
+
+### Typage des getters et actions personnalisés
+
+```typescript
+// Les getters et actions reçoivent le store typé
+getTodosByPriority: (store: BaseEntityStore<Todo>) => (priority: Todo['priority']) => {
+  // store est entièrement typé avec toutes les méthodes d'entités
+  const getWhere = store.getWhere()
+  return getWhere(todo => todo.priority === priority)
+}
+```
+
+### Typage de l'état personnalisé
+
+```typescript
+// L'état personnalisé est fusionné avec l'état des entités
+state: {
+  ui: {
+    isLoading: false,
+    error: null as string | null
+  } as TodoUIState
+}
+
+// TypeScript sait que store.entities.ui existe et est typé
+store.entities.ui.isLoading = true // ✅ TypeScript accepte boolean
+```
+
+### Avantages du nouveau système de types
+
+1. **Sécurité des types** : Plus de `any`, tous les types sont vérifiés
+2. **Autocomplétion** : IntelliSense complet pour toutes les méthodes
+3. **Vérification d'erreurs** : TypeScript détecte les erreurs à la compilation
+4. **Types Pinia natifs** : Compatibilité parfaite avec l'écosystème Pinia
+5. **Extensibilité** : Types génériques pour tous les cas d'usage
+
+## ✨ Avantages
+
+1. **Flexibilité maximale** : Étendez vos stores comme dans un store Pinia classique
+2. **Gestion automatique des entités** : Toutes les méthodes de base sont incluses
+3. **Type safety avancé** : Support TypeScript complet avec types Pinia natifs
+4. **Performance** : Utilise la réactivité native de Pinia
+5. **Extensibilité** : Ajoutez facilement des getters, actions et état personnalisés
+6. **Compatibilité** : Fonctionne avec tous les plugins Pinia existants
+7. **Simplicité** : Une seule fonction avec des options intégrées
+
+## 📚 API complète
+
+### Options de configuration
+
+```typescript
+interface PiniaEntityStoreOptions<T extends WithId> {
+  getters?: Record<string, (store: BaseEntityStore<T>) => (...args: unknown[]) => unknown>
+  actions?: Record<string, (store: BaseEntityStore<T>) => (...args: unknown[]) => unknown>
+  state?: Record<string, unknown>
+  storeName?: string
+}
+```
+
+### Méthodes de base incluses
+
+- **Getters** : `getOne`, `getAll`, `getAllArray`, `getAllIds`, `getCurrent`, `getActive`, `getWhere`, `getWhereArray`, `getFirstWhere`, `getMissingIds`, `getIsEmpty`, `isDirty`
+- **Actions** : `createOne`, `createMany`, `updateOne`, `updateMany`, `deleteOne`, `deleteMany`, `setCurrent`, `setCurrentById`, `removeCurrent`, `removeCurrentById`, `setActive`, `resetActive`, `setIsDirty`, `setIsNotDirty`
+
+### État de base
+
+```typescript
+interface State<T extends WithId> {
+  entities: {
+    byId: Record<Id, T & { $isDirty: boolean }>
+    allIds: Id[]
+    current: T & { $isDirty: boolean } | null
+    currentById: Id | null
+    active: Id[]
+  }
+}
+```
+
+## 🎯 Bonnes pratiques
+
+1. **Getters personnalisés** : Utilisez-les pour la logique de filtrage, tri et calculs
+2. **Actions personnalisées** : Utilisez-les pour les opérations métier complexes
+3. **État personnalisé** : Utilisez-le pour l'état UI, les filtres et la configuration
+4. **Type safety** : Définissez des interfaces claires pour vos entités et extensions
+5. **Réactivité** : Profitez de la réactivité automatique de Pinia pour vos extensions
+6. **Types stricts** : Utilisez des types union et des assertions de type pour plus de sécurité
+
+## 🚀 Cas d'usage avancés
+
+- **Gestion des formulaires** : État de validation, erreurs, soumission
+- **Filtrage et recherche** : Filtres complexes, recherche en temps réel
+- **Gestion des permissions** : Vérification des droits d'accès
+- **Synchronisation** : État de synchronisation avec le serveur
+- **Historique** : Gestion des actions annuler/rétablir
+- **Mode hors ligne** : État de connectivité et cache local

--- a/packages/pinia-adapter/src/core/createActions.test.ts
+++ b/packages/pinia-adapter/src/core/createActions.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { WithId } from '../types/WithId.js';
+import createActions from './createActions.js';
+import createState from './createState.js';
+
+// Test entity interface
+interface User extends WithId {
+  name: string;
+  email: string;
+  age: number;
+}
+
+describe('createActions', () => {
+  let state: ReturnType<typeof createState<User>>;
+  let actions: ReturnType<typeof createActions<User>>;
+
+  beforeEach(() => {
+    state = createState<User>();
+    actions = createActions(state);
+  });
+
+  describe('createOne', () => {
+    test('should create single entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.createOne(user);
+      
+      expect(state.entities.byId[1]).toBeDefined();
+      expect(state.entities.byId[1]?.name).toBe('John');
+      expect(state.entities.byId[1]?.$isDirty).toBe(false);
+      expect(state.entities.allIds).toContain(1);
+    });
+
+    test('should not duplicate id in allIds if entity already exists', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.createOne(user);
+      actions.createOne(user); // Try to create again
+      
+      expect(state.entities.allIds.filter(id => id === 1)).toHaveLength(1);
+    });
+
+    test('should update existing entity if id already exists', () => {
+      const user1: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      const user2: User = { id: 1, name: 'John Updated', email: 'john.updated@example.com', age: 31 };
+      
+      actions.createOne(user1);
+      actions.createOne(user2);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[1]?.email).toBe('john.updated@example.com');
+      expect(state.entities.byId[1]?.age).toBe(31);
+    });
+  });
+
+  describe('createMany', () => {
+    test('should create multiple entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 },
+        { id: 3, name: 'Bob', email: 'bob@example.com', age: 35 }
+      ];
+      
+      actions.createMany(users);
+      
+      expect(state.entities.allIds).toHaveLength(3);
+      expect(state.entities.allIds).toContain(1);
+      expect(state.entities.allIds).toContain(2);
+      expect(state.entities.allIds).toContain(3);
+      
+      expect(state.entities.byId[1]?.name).toBe('John');
+      expect(state.entities.byId[2]?.name).toBe('Jane');
+      expect(state.entities.byId[3]?.name).toBe('Bob');
+    });
+
+    test('should handle empty array', () => {
+      actions.createMany([]);
+      
+      expect(state.entities.allIds).toHaveLength(0);
+      expect(Object.keys(state.entities.byId)).toHaveLength(0);
+    });
+  });
+
+  describe('setCurrent', () => {
+    test('should set current entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.setCurrent(user);
+      
+      expect(state.entities.current).toBeDefined();
+      expect(state.entities.current?.name).toBe('John');
+      expect(state.entities.current?.$isDirty).toBe(false);
+    });
+
+    test('should update current entity if already set', () => {
+      const user1: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      const user2: User = { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 };
+      
+      actions.setCurrent(user1);
+      actions.setCurrent(user2);
+      
+      expect(state.entities.current?.id).toBe(2);
+      expect(state.entities.current?.name).toBe('Jane');
+    });
+  });
+
+  describe('removeCurrent', () => {
+    test('should remove current entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.setCurrent(user);
+      expect(state.entities.current).toBeDefined();
+      
+      actions.removeCurrent();
+      expect(state.entities.current).toBeNull();
+    });
+
+    test('should handle removing when no current entity', () => {
+      expect(state.entities.current).toBeNull();
+      
+      actions.removeCurrent();
+      expect(state.entities.current).toBeNull();
+    });
+  });
+
+  describe('updateOne', () => {
+    test('should update existing entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      const updatedUser: User = { id: 1, name: 'John Updated', email: 'john.updated@example.com', age: 31 };
+      actions.updateOne(1, updatedUser);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[1]?.email).toBe('john.updated@example.com');
+      expect(state.entities.byId[1]?.age).toBe(31);
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+    });
+
+    test('should create entity if id does not exist', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      
+      actions.updateOne(1, user);
+      
+      expect(state.entities.byId[1]).toBeDefined();
+      expect(state.entities.byId[1]?.name).toBe('John');
+      expect(state.entities.allIds).toContain(1);
+    });
+
+    test('should preserve existing fields not in payload', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      const updatedUser: User = { id: 1, name: 'John Updated', age: 31 } as User;
+      actions.updateOne(1, updatedUser);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[1]?.email).toBe('john@example.com'); // Preserved
+      expect(state.entities.byId[1]?.age).toBe(31);
+    });
+  });
+
+  describe('updateMany', () => {
+    test('should update multiple entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      actions.createMany(users);
+      
+      const updatedUsers: User[] = [
+        { id: 1, name: 'John Updated', email: 'john.updated@example.com', age: 31 },
+        { id: 2, name: 'Jane Updated', email: 'jane.updated@example.com', age: 26 }
+      ];
+      
+      actions.updateMany(updatedUsers);
+      
+      expect(state.entities.byId[1]?.name).toBe('John Updated');
+      expect(state.entities.byId[2]?.name).toBe('Jane Updated');
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+      expect(state.entities.byId[2]?.$isDirty).toBe(true);
+    });
+
+    test('should handle empty array', () => {
+      actions.updateMany([]);
+      expect(state.entities.allIds).toHaveLength(0);
+    });
+  });
+
+  describe('deleteOne', () => {
+    test('should delete entity by id', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      expect(state.entities.byId[1]).toBeDefined();
+      expect(state.entities.allIds).toContain(1);
+      
+      actions.deleteOne(1);
+      
+      expect(state.entities.byId[1]).toBeUndefined();
+      expect(state.entities.allIds).not.toContain(1);
+    });
+
+    test('should handle deleting non-existent entity', () => {
+      const initialLength = state.entities.allIds.length;
+      
+      actions.deleteOne(999);
+      
+      expect(state.entities.allIds.length).toBe(initialLength);
+    });
+  });
+
+  describe('deleteMany', () => {
+    test('should delete multiple entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 },
+        { id: 3, name: 'Bob', email: 'bob@example.com', age: 35 }
+      ];
+      actions.createMany(users);
+      
+      expect(state.entities.allIds).toHaveLength(3);
+      
+      actions.deleteMany([1, 3]);
+      
+      expect(state.entities.allIds).toHaveLength(1);
+      expect(state.entities.allIds).toContain(2);
+      expect(state.entities.byId[1]).toBeUndefined();
+      expect(state.entities.byId[3]).toBeUndefined();
+      expect(state.entities.byId[2]).toBeDefined();
+    });
+
+    test('should handle empty array', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.deleteMany([]);
+      
+      expect(state.entities.allIds).toContain(1);
+      expect(state.entities.byId[1]).toBeDefined();
+    });
+  });
+
+  describe('setActive', () => {
+    test('should set entity as active', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.setActive(1);
+      
+      expect(state.entities.active).toContain(1);
+    });
+
+    test('should not duplicate active entity', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.setActive(1);
+      actions.setActive(1); // Try to set again
+      
+      expect(state.entities.active.filter(id => id === 1)).toHaveLength(1);
+    });
+
+    test('should handle non-existent entity', () => {
+      actions.setActive(999);
+      expect(state.entities.active).toHaveLength(0);
+    });
+  });
+
+  describe('resetActive', () => {
+    test('should clear all active entities', () => {
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      actions.createMany(users);
+      
+      actions.setActive(1);
+      actions.setActive(2);
+      
+      expect(state.entities.active).toHaveLength(2);
+      
+      actions.resetActive();
+      
+      expect(state.entities.active).toHaveLength(0);
+    });
+
+    test('should handle reset when no active entities', () => {
+      expect(state.entities.active).toHaveLength(0);
+      
+      actions.resetActive();
+      
+      expect(state.entities.active).toHaveLength(0);
+    });
+  });
+
+  describe('setIsDirty', () => {
+    test('should mark entity as dirty', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      expect(state.entities.byId[1]?.$isDirty).toBe(false);
+      
+      actions.setIsDirty(1);
+      
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+    });
+
+    test('should handle non-existent entity', () => {
+      actions.setIsDirty(999);
+      // Should not throw error
+    });
+  });
+
+  describe('setIsNotDirty', () => {
+    test('should mark entity as not dirty', () => {
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 };
+      actions.createOne(user);
+      
+      actions.setIsDirty(1);
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+      
+      actions.setIsNotDirty(1);
+      
+      expect(state.entities.byId[1]?.$isDirty).toBe(false);
+    });
+
+    test('should handle non-existent entity', () => {
+      actions.setIsNotDirty(999);
+      // Should not throw error
+    });
+  })
+
+  describe('Integration tests', () => {
+    test('should handle complex workflow', () => {
+      // Create entities
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      actions.createMany(users);
+      
+      // Set current and active
+      actions.setCurrent(users[0]);
+      actions.setActive(1);
+      actions.setActive(2);
+      
+      // Update entity
+      actions.updateOne(1, { id: 1, name: 'John Updated', email: 'john@example.com', age: 31 });
+      
+      // Verify state
+      expect(state.entities.allIds).toHaveLength(2);
+      expect(state.entities.current?.name).toBe('John');
+      expect(state.entities.active).toHaveLength(2);
+      expect(state.entities.byId[1]?.$isDirty).toBe(true);
+      
+      // Delete entity
+      actions.deleteOne(2);
+      
+      expect(state.entities.allIds).toHaveLength(1);
+      expect(state.entities.active).toHaveLength(1);
+      expect(state.entities.byId[2]).toBeUndefined();
+    });
+  });
+});
+

--- a/packages/pinia-adapter/src/core/createActions.ts
+++ b/packages/pinia-adapter/src/core/createActions.ts
@@ -1,0 +1,157 @@
+import type { State } from '../types/State.js'
+import type { Id, WithId } from '../types/WithId.js'
+
+export default function createActions<T extends WithId>(state: State<T>) {
+  return {
+    /**
+   * Create single entity in Store
+   * @param payload Entity to create
+   */
+    createOne(payload: T): void {
+      if (!state.entities.byId[payload.id] && !state.entities.allIds.includes(payload.id)) {
+        state.entities.allIds.push(payload.id)
+      }
+      state.entities.byId[payload.id] = { ...payload, $isDirty: false }
+    },
+
+    /**
+   * Create Many entity in store
+   * @params payload Entities to create
+   */
+    createMany(payload: T[]): void {
+      payload.forEach(entity => this.createOne(entity))
+    },
+
+    /**
+     * set current used entity
+     * @param payload
+     */
+    setCurrent(payload: T) {
+      state.entities.current = { ...payload, $isDirty: false }
+    },
+
+    /**
+   * remove current used entity
+   * @param payload
+   */
+    removeCurrent() {
+      state.entities.current = null
+    },
+
+    /**
+     * Update One entiy in Store
+     * @param id of entity to update
+     * @param payload data of entity to update
+     */
+    updateOne(id: Id, payload: T): void {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id] = {
+          ...state.entities.byId[id],
+          ...payload,
+          $isDirty: true,
+        }
+      }
+      else {
+        this.createOne(payload)
+      }
+    },
+
+    /**
+     * Update many entities in Store
+     * @param ids of entities to update
+     * @param payload data of entity to update
+     */
+    updateMany(payload: T[]): void {
+      payload.forEach(entity => this.updateOne(entity.id, entity))
+    },
+
+    /**
+   * Delete one entity in Store
+   * @param id of entity to delete
+   */
+    deleteOne(id: Id) {
+      delete state.entities.byId[id]
+      state.entities.allIds = state.entities.allIds.filter(entityId => entityId !== id)
+      state.entities.active = state.entities.active.filter(entityId => entityId !== id)
+    },
+
+    /**
+   * delete many entities in Store
+   * @param ids of entities to delete
+   */
+    deleteMany(ids: Id[]) {
+      ids.forEach(id => this.deleteOne(id))
+    },
+
+    /**
+     * reset entities.active to an empty Array
+     */
+    resetActive() {
+      state.entities.active = []
+    },
+
+    /**
+   * set one entity as active with his id
+   * @param id of entity to set as active
+   */
+    setActive(id: Id) {
+      if (!state.entities.active.includes(id) && state.entities.byId[id])
+        state.entities.active.push(id)
+    },
+
+    /**
+   * set $isDirty property to true to know if the entity has been modified or not
+   * @param id of entity
+   */
+    setIsDirty(id: Id) {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id] = {
+          ...state.entities.byId[id]!,
+          $isDirty: true,
+        }
+      }
+    },
+
+    /**
+   * set $isDirty property to false to know if the entity has been modified or not
+   * @param id of entity
+   */
+    setIsNotDirty(id: Id) {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id] = {
+          ...state.entities.byId[id]!,
+          $isDirty: false,
+        }
+      }
+    },
+
+    /**
+     * update field of an entity
+     * @param field: string field to update
+     * @param id: Id of entity
+     */
+    updateField<K extends keyof T>(field: K, value: (T & { $isDirty: boolean })[K], id: Id) {
+      if (state.entities.byId[id]) {
+        state.entities.byId[id]![field] = value
+        this.setIsDirty(id)
+      }
+    },
+
+    /**
+     * set currentById entity
+     * @param payload
+     */
+    setCurrentById(payload: Id) {
+      if (state.entities.byId[payload]) {
+        state.entities.currentById = payload
+      }
+    },
+
+    /**
+     * remove currentById entity
+     */
+    removeCurrentById() {
+      state.entities.currentById = null
+    },
+  }
+}

--- a/packages/pinia-adapter/src/core/createGetters.test.ts
+++ b/packages/pinia-adapter/src/core/createGetters.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import type { WithId } from '../types/WithId.js';
+import createGetters from './createGetters.js';
+import createState from './createState.js';
+
+// Test entity interface
+interface User extends WithId {
+  name: string;
+  email: string;
+  age: number;
+}
+
+type TemporaryState = ReturnType<typeof createState<User>> & ReturnType<typeof createGetters<User>>;
+
+describe('createGetters', () => {
+  let state: TemporaryState;
+
+  beforeEach(() => {
+    state = createState<User>() as TemporaryState;
+    state = {
+      ...state,
+      ...createGetters(state),
+    };
+    
+    // Add some test data
+    const user1: User & { $isDirty: boolean } = { id: 1, name: 'John', email: 'john@example.com', age: 30, $isDirty: false };
+    const user2: User & { $isDirty: boolean } = { id: 2, name: 'Jane', email: 'jane@example.com', age: 25, $isDirty: false };
+    const user3: User & { $isDirty: boolean } = { id: 3, name: 'Bob', email: 'bob@example.com', age: 35, $isDirty: true };
+    
+    state.entities.byId[1] = user1;
+    state.entities.byId[2] = user2;
+    state.entities.byId[3] = user3;
+    state.entities.allIds = [1, 2, 3];
+    state.entities.current = user1;
+    state.entities.currentById = 1;
+    state.entities.active = [1, 2];
+  });
+
+  describe('findOneById (deprecated)', () => {
+    test('should find entity by id', () => {
+      const findOne = state.findOneById();
+      const user = findOne(1);
+      
+      expect(user).toBeDefined();
+      expect(user?.name).toBe('John');
+      expect(user?.id).toBe(1);
+    });
+
+    test('should return undefined for non-existent id', () => {
+      const findOne = state.findOneById();
+      const user = findOne(999);
+      
+      expect(user).toBeUndefined();
+    });
+  });
+
+  describe('findManyById (deprecated)', () => {
+    test('should find multiple entities by ids', () => {
+      const findMany = state.findManyById();
+      const users = findMany([1, 2]);
+      
+      expect(users).toHaveLength(2);
+      expect(users[0]?.name).toBe('John');
+      expect(users[1]?.name).toBe('Jane');
+    });
+
+    test('should filter out non-existent ids', () => {
+      const findMany = state.findManyById();
+      const users = findMany([1, 999, 2]);
+      
+      expect(users).toHaveLength(2);
+      expect(users[0]?.name).toBe('John');
+      expect(users[1]?.name).toBe('Jane');
+    });
+
+    test('should return empty array for non-existent ids', () => {
+      const findMany = state.findManyById();
+      const users = findMany([999, 888]);
+      
+      expect(users).toHaveLength(0);
+    });
+  });
+
+  describe('getAll', () => {
+    test('should return all entities as dictionary', () => {
+      const all = state.getAll();
+      
+      expect(all).toBeDefined();
+      expect(Object.keys(all)).toHaveLength(3);
+      expect(all[1]?.name).toBe('John');
+      expect(all[2]?.name).toBe('Jane');
+      expect(all[3]?.name).toBe('Bob');
+    });
+
+    test('should return empty object for empty state', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      const all = emptyGetters.getAll();
+      
+      expect(all).toEqual({});
+    });
+  });
+
+  describe('getAllArray', () => {
+    test('should return all entities as array', () => {
+      const all = state.getAllArray();
+      
+      expect(Array.isArray(all)).toBe(true);
+      expect(all).toHaveLength(3);
+      expect(all.map(u => u.name)).toContain('John');
+      expect(all.map(u => u.name)).toContain('Jane');
+      expect(all.map(u => u.name)).toContain('Bob');
+    });
+
+    test('should return empty array for empty state', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      const all = emptyGetters.getAllArray();
+      
+      expect(all).toEqual([]);
+    });
+  });
+
+  describe('getAllIds', () => {
+    test('should return all entity ids', () => {
+      const ids = state.getAllIds();
+      
+      expect(Array.isArray(ids)).toBe(true);
+      expect(ids).toHaveLength(3);
+      expect(ids).toContain(1);
+      expect(ids).toContain(2);
+      expect(ids).toContain(3);
+    });
+
+    test('should return empty array for empty state', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      const ids = emptyGetters.getAllIds();
+      
+      expect(ids).toEqual([]);
+    });
+  });
+
+  describe('getMissingIds', () => {
+    test('should return missing ids', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 4, 5]);
+      
+      expect(missing).toHaveLength(2);
+      expect(missing).toContain(4);
+      expect(missing).toContain(5);
+    });
+
+    test('should return empty array when all ids exist', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 3]);
+      
+      expect(missing).toHaveLength(0);
+    });
+
+    test('should handle duplicates when canHaveDuplicates is false', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 4, 4, 5], false);
+      
+      expect(missing).toHaveLength(2);
+      expect(missing).toContain(4);
+      expect(missing).toContain(5);
+    });
+
+    test('should handle duplicates when canHaveDuplicates is true', () => {
+      const getMissing = state.getMissingIds();
+      const missing = getMissing([1, 2, 4, 4, 5], true);
+      
+      expect(missing).toHaveLength(3);
+      expect(missing).toContain(4);
+      expect(missing).toContain(4);
+      expect(missing).toContain(5);
+    });
+  });
+
+  describe('getMissingEntities', () => {
+    test('should return missing entities', () => {
+      const entities: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 4, name: 'Alice', email: 'alice@example.com', age: 28 },
+        { id: 5, name: 'Charlie', email: 'charlie@example.com', age: 32 }
+      ];
+      
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing(entities);
+      
+      expect(missing).toHaveLength(2);
+      expect(missing[0]?.name).toBe('Alice');
+      expect(missing[1]?.name).toBe('Charlie');
+    });
+
+    test('should return empty array when all entities exist', () => {
+      const entities: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      ];
+      
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing(entities);
+      
+      expect(missing).toHaveLength(0);
+    });
+
+    test('should handle empty array', () => {
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing([]);
+      
+      expect(missing).toEqual([]);
+    });
+
+    test('should handle null/undefined array', () => {
+      const getMissing = state.getMissingEntities();
+      const missing = getMissing(null as any);
+      
+      expect(missing).toEqual([]);
+    });
+  });
+
+  describe('getWhere', () => {
+    test('should filter entities by predicate', () => {
+      const getWhere = state.getWhere();
+      const adults = getWhere(user => user.age >= 30);
+      
+      expect(Object.keys(adults)).toHaveLength(2);
+      expect(adults[1]?.name).toBe('John');
+      expect(adults[3]?.name).toBe('Bob');
+    });
+
+    test('should return all entities when filter is not a function', () => {
+      const getWhere = state.getWhere();
+      const all = getWhere(null as any);
+      
+      expect(Object.keys(all)).toHaveLength(3);
+    });
+
+    test('should return empty object when no entities match filter', () => {
+      const getWhere = state.getWhere();
+      const seniors = getWhere(user => user.age >= 60);
+      
+      expect(Object.keys(seniors)).toHaveLength(0);
+    });
+  });
+
+  describe('getWhereArray', () => {
+    test('should filter entities by predicate and return array', () => {
+      const getWhereArray = state.getWhereArray();
+      const adults = getWhereArray(user => user.age >= 30);
+      
+      expect(Array.isArray(adults)).toBe(true);
+      expect(adults).toHaveLength(2);
+      expect(adults.map(u => u.name)).toContain('John');
+      expect(adults.map(u => u.name)).toContain('Bob');
+    });
+
+    test('should return all entities when filter is not a function', () => {
+      const getWhereArray = state.getWhereArray();
+      const all = getWhereArray(null as any);
+      
+      expect(Array.isArray(all)).toBe(true);
+      expect(all).toHaveLength(3);
+    });
+
+    test('should return empty array when no entities match filter', () => {
+      const getWhereArray = state.getWhereArray();
+      const seniors = getWhereArray(user => user.age >= 60);
+      
+      expect(Array.isArray(seniors)).toBe(true);
+      expect(seniors).toHaveLength(0);
+    });
+  });
+
+  describe('getCurrent', () => {
+    test('should return current entity', () => {
+      const current = state.getCurrent();
+      
+      expect(current).toBeDefined();
+      expect(current?.name).toBe('John');
+      expect(current?.id).toBe(1);
+    });
+
+    test('should return null when no current entity', () => {
+      state.entities.current = null;
+      const current = state.getCurrent();
+      
+      expect(current).toBeNull();
+    });
+  });
+
+  describe('getCurrentById', () => {
+    test('should return current entity', () => {
+      const currentEntity = state.getCurrentById();
+      
+      expect(currentEntity).toBeDefined();
+      expect(currentEntity?.id).toBe(1);
+      expect(currentEntity?.name).toBe('John');
+    });
+
+    test('should return null when no current entity', () => {
+      state.entities.currentById = null;
+      const currentId = state.getCurrentById();
+      
+      expect(currentId).toBeNull();
+    });
+  });
+
+  describe('getActive', () => {
+    test('should return active entities', () => {
+      const active = state.getActive();
+      
+      expect(Array.isArray(active)).toBe(true);
+      expect(active).toHaveLength(2);
+      expect(active).toContain(1);
+      expect(active).toContain(2);
+    });
+
+    test('should return empty array when no active entities', () => {
+      state.entities.active = [];
+      const active = state.getActive();
+      
+      expect(active).toEqual([]);
+    });
+  });
+
+  describe('getFirstActive', () => {
+    test('should return first active entity', () => {
+      const first = state.getFirstActive();
+      
+      expect(first).toBeDefined();
+      expect(first).toBe(1);
+    });
+
+    test('should return undefined when no active entities', () => {
+      state.entities.active = [];
+      const first = state.getFirstActive();
+      
+      expect(first).toBeUndefined();
+    });
+  });
+
+  describe('isAlreadyInStore', () => {
+    test('should return true for existing entity', () => {
+      const isInStore = state.isAlreadyInStore();
+      expect(isInStore(1)).toBe(true);
+      expect(isInStore(2)).toBe(true);
+      expect(isInStore(3)).toBe(true);
+    });
+
+    test('should return false for non-existent entity', () => {
+      const isInStore = state.isAlreadyInStore();
+      expect(isInStore(999)).toBe(false);
+    });
+  });
+
+  describe('isAlreadyActive', () => {
+    test('should return true for active entity', () => {
+      const isActive = state.isAlreadyActive();
+      expect(isActive(1)).toBe(true);
+      expect(isActive(2)).toBe(true);
+    });
+
+    test('should return false for non-active entity', () => {
+      const isActive = state.isAlreadyActive();
+      expect(isActive(3)).toBe(false);
+    });
+
+    test('should return false for non-existent entity', () => {
+      const isActive = state.isAlreadyActive();
+      expect(isActive(999)).toBe(false);
+    });
+  });
+
+  describe('isDirty', () => {
+    test('should return dirty status of entity', () => {
+      const isDirty = state.isDirty();
+      expect(isDirty(1)).toBe(false);
+      expect(isDirty(2)).toBe(false);
+      expect(isDirty(3)).toBe(true);
+    });
+
+    test('should return false for non-existent entity', () => {
+      const isDirty = state.isDirty();
+      expect(isDirty(999)).toBe(false);
+    });
+  });
+
+  describe('isEmpty', () => {
+    test('should return false when entities exist', () => {
+      expect(state.getIsEmpty()).toBe(false);
+    });
+
+    test('should return true when no entities exist', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      
+      expect(emptyGetters.getIsEmpty()).toBe(true);
+    });
+  });
+
+  describe('isNotEmpty', () => {
+    test('should return true when entities exist', () => {
+      expect(state.getIsNotEmpty()).toBe(true);
+    });
+
+    test('should return false when no entities exist', () => {
+      const emptyState = createState<User>();
+      const emptyGetters = createGetters(emptyState);
+      
+      expect(emptyGetters.getIsNotEmpty()).toBe(false);
+    });
+  });
+});
+

--- a/packages/pinia-adapter/src/core/createGetters.ts
+++ b/packages/pinia-adapter/src/core/createGetters.ts
@@ -1,0 +1,261 @@
+
+import type { State } from '../types/State.js'
+import type { Id, WithId } from '../types/WithId.js'
+
+export default function createGetters<T extends WithId>(currentState: State<T>) {
+  /**
+   * Get a single item from the state by its id.
+   * @param id - The id of the item
+   * @Deprecated use getOne
+   */
+  function findOneById(state = currentState) {
+    return (id: Id) => state.entities.byId[id]
+  }
+
+  /**
+   * Get multiple items from the state by their ids.
+   * @param ids - The ids of items
+   * @Deprecated use getMany
+   */
+  function findManyById(state = currentState) {
+    return (ids: Id[]) => ids.map(id => state.entities.byId[id]).filter(id => id)
+  }
+
+  /**
+   * Get all the items from the state as a dictionnary of values.
+   */
+  function getAll(state = currentState) {
+    return state.entities.byId
+  }
+
+  /**
+   * Get all items from the state as an array of values.
+   */
+  function getAllArray(state = currentState) {
+    return Object.values(state.entities.byId)
+  }
+
+  /**
+   * Get an array containing the ids of all the items in the state.
+   */
+  function getAllIds(state = currentState) {
+    return state.entities.allIds
+  }
+
+  /**
+   * @param ids Id[]
+   * @param canHaveDuplicates boolean not required
+   * @returns returns a list of missing IDs in the store compared to the ids passed to the getter. with an option to filter out duplicates
+   */
+  function getMissingIds(state = currentState) {
+    return (ids: Id[], canHaveDuplicates?: boolean) => {
+      const filteredIds = ids.filter(id => !state.entities.allIds.includes(id))
+      if (!canHaveDuplicates)
+        return Array.from(new Set(filteredIds))
+
+      return filteredIds
+    }
+  }
+
+  /**
+  * @param entitiesArray T[]
+  * @returns returns a list of missing entities in the store
+  */
+  function getMissingEntities(state = currentState) {
+    return (entitiesArray: T[]) => {
+      if (entitiesArray?.length > 0)
+        return entitiesArray.filter(entity => !state.entities.allIds.includes(entity.id))
+
+      return []
+    }
+  }
+
+  /**
+   * Get all the items that pass the given filter callback as a dictionnary of values.
+   * @param filter - The filtering callback that will be used to filter the items.
+   */
+  function getWhere(state = currentState) {
+    return (filter: (arg: T & { $isDirty: boolean }) => boolean | null) => {
+      if (typeof filter !== 'function')
+        return state.entities.byId
+
+      return state.entities.allIds.reduce((acc: Record<Id, T & { $isDirty: boolean }>, id: Id) => {
+        const item = state.entities.byId[id]
+        if (!item || !filter(item))
+          return acc
+
+        acc[id] = item
+        return acc
+      }, {} as Record<Id, T & { $isDirty: boolean }>)
+    }
+  }
+
+  /**
+   * Get all the items that pass the given filter callback as an array of values.
+   * @param filter - The filtering callback that will be used to filter the items.
+   */
+  function getWhereArray(state = currentState) {
+    return (filter: (arg: T & { $isDirty: boolean }) => boolean | null) => {
+      if (typeof filter !== 'function')
+        return Object.values(state.entities.byId)
+
+      return Object.values(state.entities.allIds.reduce((acc: Record<Id, T & { $isDirty: boolean }>, id: Id) => {
+        const item = state.entities.byId[id]
+        if (!item || !filter(item))
+          return acc
+
+        acc[id] = item
+        return acc
+      }, {} as Record<Id, T & { $isDirty: boolean }>))
+    }
+  }
+
+  /**
+   * Get the first item that passes the given filter callback.
+   * @param filter - The filtering callback that will be used to filter the items.
+   * @returns The first item that passes the filter, or the first item in the state if no filter is provided.
+   */
+  function getFirstWhere(state = currentState) {
+    return (filter: (arg: T & { $isDirty: boolean }) => boolean | null) => {
+      if (typeof filter !== 'function')
+        return Object.values(state.entities.byId)[0]
+
+      return Object.values(state.entities.allIds.reduce((acc: Record<Id, T & { $isDirty: boolean }>, id: Id) => {
+        const item = state.entities.byId[id]
+        if (!item || !filter(item))
+          return acc
+
+        acc[id] = item
+        return acc
+      }, {} as Record<Id, T & { $isDirty: boolean }>))[0]
+    }
+  }
+
+  /**
+   * Returns a boolean indicating wether or not the state is empty (contains no items).
+   */
+  function getIsEmpty(state = currentState) {
+    return state.entities.allIds.length === 0
+  }
+
+  /**
+   * Returns a boolean indicating wether or not the state is not empty (contains items).
+  */
+  function getIsNotEmpty(state = currentState) {
+    return state.entities.allIds.length > 0
+  }
+
+  /**
+   * @return current entity stored in state
+   */
+  function getCurrent(state = currentState) {
+    return state.entities.current
+  }
+
+  /**
+   * Get a single item from the state by its id.
+   * @param id - The id of the item
+   */
+  function getOne(state = currentState) {
+    return (id: Id) => state.entities.byId[id]
+  }
+
+  /**
+   * Get a array of items from the state by their ids.
+   * @param ids - ids of items
+   */
+  function getMany(state = currentState) {
+    return (ids: Id[]) => ids.map(id => state.entities.byId[id]).filter((item): item is T & { $isDirty: boolean } => item !== undefined)
+  }
+
+  /**
+   *  @return array of active entities stored in state
+   */
+  function getActive(state = currentState) {
+    return state.entities.active
+  }
+
+  /**
+   *  @return first entity get from array of active entities stored in state
+   */
+  function getFirstActive(state = currentState) {
+    return state.entities.active[0]
+  }
+
+  /**
+   * helper to determine if the entity is already stored in state
+   * @param id - The id of the item
+   *  @return boolean
+   */
+  function isAlreadyInStore(state = currentState) {
+    return (id: Id) => state.entities.allIds.includes(id)
+  }
+
+  /**
+   * helper to determine if the entity is already set as Active in state
+   * @param id - The id of the item
+   *  @return boolean
+   */
+  function isAlreadyActive(state = currentState) {
+    return (id: Id) => state.entities.active.includes(id)
+  }
+
+  /**
+   * helper to know if an entity has been modified
+   *  @param id - The id of the item
+   *  @return boolean
+   */
+  function isDirty(state = currentState) {
+    return (id: Id) => state.entities.byId[id]?.$isDirty || false
+  }
+
+  /**
+   * Search for an entity in the state
+   * @param field - The field to search for
+   * @return array of entities
+   */
+  function search(state = currentState) {
+    return (field: string) => Object.values(state.entities.byId)
+      .filter(item => {
+        const regex = new RegExp(field, 'i')
+        for (const value of Object.values(item)) {
+          if (typeof value === 'string' && regex.test(value)) {
+            return true
+          }
+        }
+        return false
+      })
+  }
+
+  /**
+   * Get currentById entity stored in state
+   */
+  function getCurrentById(state = currentState) {
+    return state.entities.currentById ? state.entities.byId[state.entities.currentById] : null
+  }
+
+  return {
+    findManyById,
+    findOneById,
+    getActive,
+    getAll,
+    getAllArray,
+    getAllIds,
+    getCurrent,
+    getFirstActive,
+    getFirstWhere,
+    getIsEmpty,
+    getIsNotEmpty,
+    getMany,
+    getMissingEntities,
+    getMissingIds,
+    getOne,
+    getWhere,
+    getWhereArray,
+    isAlreadyActive,
+    isAlreadyInStore,
+    isDirty,
+    search,
+    getCurrentById,
+  }
+}

--- a/packages/pinia-adapter/src/core/createState.test.ts
+++ b/packages/pinia-adapter/src/core/createState.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import type { WithId } from '../types/WithId.js';
+import createState from './createState.js';
+
+// Test entity interface
+interface User extends WithId {
+  name: string;
+  email: string;
+  age: number;
+}
+
+describe('createState', () => {
+  test('should create initial state with correct structure', () => {
+    const state = createState<User>();
+    
+    expect(state).toBeDefined();
+    expect(state.entities).toBeDefined();
+    expect(state.entities.byId).toEqual({});
+    expect(state.entities.allIds).toEqual([]);
+    expect(state.entities.current).toBeNull();
+    expect(state.entities.currentById).toBeNull();
+    expect(state.entities.active).toEqual([]);
+  });
+
+  test('should create state with correct types', () => {
+    const state = createState<User>();
+    
+    // Test that byId is a Record with Id keys and User & { $isDirty: boolean } values
+    expect(typeof state.entities.byId).toBe('object');
+    expect(Array.isArray(state.entities.byId)).toBe(false);
+    
+    // Test that allIds is an array
+    expect(Array.isArray(state.entities.allIds)).toBe(true);
+    
+    // Test that current can be null
+    expect(state.entities.current).toBeNull();
+    
+    // Test that currentById can be null
+    expect(state.entities.currentById).toBeNull();
+    
+    // Test that active is an array
+    expect(Array.isArray(state.entities.active)).toBe(true);
+  });
+
+  test('should create independent state instances', () => {
+    const state1 = createState<User>();
+    const state2 = createState<User>();
+    
+    // States should be different objects
+    expect(state1).not.toBe(state2);
+    expect(state1.entities).not.toBe(state2.entities);
+    expect(state1.entities.byId).not.toBe(state2.entities.byId);
+    expect(state1.entities.allIds).not.toBe(state2.entities.allIds);
+    expect(state1.entities.active).not.toBe(state2.entities.active);
+  });
+
+  test('should work with different entity types', () => {
+    interface Product extends WithId {
+      name: string;
+      price: number;
+    }
+    
+    const userState = createState<User>();
+    const productState = createState<Product>();
+    
+    expect(userState.entities.byId).toEqual({});
+    expect(productState.entities.byId).toEqual({});
+    
+    // Both should have the same structure but be different instances
+    expect(userState).not.toBe(productState);
+  });
+});

--- a/packages/pinia-adapter/src/core/createState.ts
+++ b/packages/pinia-adapter/src/core/createState.ts
@@ -1,0 +1,14 @@
+import type { State } from '../types/State.js'
+import type { WithId } from '../types/WithId.js'
+
+export default function<T extends WithId>(): State<T & { $isDirty: boolean }> {
+  return {
+    entities: {
+      byId: {},
+      allIds: [],
+      current: null,
+      currentById: null,
+      active: [],
+    },
+  }
+}

--- a/packages/pinia-adapter/src/core/index.ts
+++ b/packages/pinia-adapter/src/core/index.ts
@@ -1,0 +1,4 @@
+// Core package index file
+export { default as createState } from './createState.js';
+export { default as createGetters } from './createGetters.js';
+export { default as createActions } from './createActions.js';

--- a/packages/pinia-adapter/src/extension.test.ts
+++ b/packages/pinia-adapter/src/extension.test.ts
@@ -1,0 +1,253 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { createPiniaEntityStore } from './index.js'
+
+interface Todo {
+  id: number
+  title: string
+  description: string
+  completed: boolean
+  priority: 'low' | 'medium' | 'high'
+  tags: string[]
+}
+
+describe('Pinia Adapter Extensions', () => {
+  let pinia: any
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  describe('Custom Getters', () => {
+    test('should add custom getters to the store', () => {
+      const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+        getters: {
+          getTodosByPriority: (store) => (priority: Todo['priority']) => {
+            const getWhere = store.getWhere()
+            return getWhere(todo => todo.priority === priority)
+          },
+          getCompletedCount: (store) => () => {
+            const getWhere = store.getWhere()
+            return Object.keys(getWhere(todo => todo.completed)).length
+          },
+          getTodosByTag: (store) => (tag: string) => {
+            const getWhere = store.getWhere()
+            return getWhere(todo => todo.tags.includes(tag))
+          },
+          getHighPriorityTodos: (store) => () => {
+            const getWhere = store.getWhere()
+            return getWhere(todo => todo.priority === 'high')
+          }
+        }
+      })
+
+      const store = useTodoStore()
+      
+      // Add some todos
+      const todos: Todo[] = [
+        { id: 1, title: 'High Priority', description: 'Important', completed: false, priority: 'high', tags: [] },
+        { id: 2, title: 'Medium Priority', description: 'Normal', completed: true, priority: 'medium', tags: [] },
+        { id: 3, title: 'Low Priority', description: 'Minor', completed: false, priority: 'low', tags: [] }
+      ]
+      
+      store.createMany(todos)
+      
+      // Test custom getters
+      const highPriorityTodos = store.getTodosByPriority('high')
+      expect(Object.keys(highPriorityTodos)).toHaveLength(1)
+      expect(highPriorityTodos[1].title).toBe('High Priority')
+      
+      const completedCount = store.getCompletedCount()
+      expect(completedCount).toBe(1)
+    })
+  })
+
+  describe('Custom Actions', () => {
+    test('should add custom actions to the store', () => {
+      const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+        actions: {
+          toggleTodo: (store) => (id: number) => {
+            const current = store.getOne()(id)
+            if (current) {
+              const updatedTodo: Todo = {
+                ...current,
+                completed: !current.completed
+              }
+              store.updateOne(id, updatedTodo)
+            }
+          },
+          addTag: (store) => (id: number, tag: string) => {
+            const current = store.getOne()(id)
+            if (current && !current.tags.includes(tag)) {
+              const updatedTodo: Todo = {
+                ...current,
+                tags: [...current.tags, tag]
+              }
+              store.updateOne(id, updatedTodo)
+            }
+          }
+        }
+      })
+
+      const store = useTodoStore()
+      
+      // Add a todo
+      const todo: Todo = { 
+        id: 1, 
+        title: 'Test Todo', 
+        description: 'Test', 
+        completed: false, 
+        priority: 'medium', 
+        tags: [] 
+      }
+      store.createOne(todo)
+      
+      // Test custom actions
+      store.toggleTodo(1)
+      expect(store.getOne()(1)?.completed).toBe(true)
+      
+      store.addTag(1, 'important')
+      expect(store.getOne()(1)?.tags).toContain('important')
+    })
+  })
+
+  describe('Custom State', () => {
+    test('should add custom state to the store', () => {
+      const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+        state: {
+          ui: {
+            isLoading: false,
+            error: null as string | null
+          },
+          filters: {
+            showCompleted: true,
+            priorityFilter: null as Todo['priority'] | null
+          }
+        }
+      })
+
+      const store = useTodoStore()
+      
+      // Test custom state
+      expect(store.entities.ui).toBeDefined()
+      expect(store.entities.ui.isLoading).toBe(false)
+      expect(store.entities.filters.showCompleted).toBe(true)
+      
+      // Modify custom state
+      store.entities.ui.isLoading = true
+      store.entities.filters.showCompleted = false
+      
+      expect(store.entities.ui.isLoading).toBe(true)
+      expect(store.entities.filters.showCompleted).toBe(false)
+    })
+  })
+
+  describe('Full Extension', () => {
+    test('should combine custom state, getters, and actions', () => {
+      const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+        state: {
+          ui: { isLoading: false, error: null as string | null },
+          filters: { showCompleted: true }
+        },
+        getters: {
+          getFilteredTodos: (store) => () => {
+            let todos = store.getAllArray()
+            if (!store.entities.filters.showCompleted) {
+              todos = todos.filter(todo => !todo.completed)
+            }
+            return todos
+          }
+        },
+        actions: {
+          setLoading: (store) => (loading: boolean) => {
+            store.entities.ui.isLoading = loading
+          },
+          toggleFilter: (store) => () => {
+            store.entities.filters.showCompleted = !store.entities.filters.showCompleted
+          }
+        }
+      })
+
+      const store = useTodoStore()
+      
+      // Add todos
+      const todos: Todo[] = [
+        { id: 1, title: 'Todo 1', description: 'Test 1', completed: false, priority: 'high', tags: [] },
+        { id: 2, title: 'Todo 2', description: 'Test 2', completed: true, priority: 'medium', tags: [] }
+      ]
+      store.createMany(todos)
+      
+      // Test custom state
+      expect(store.entities.ui.isLoading).toBe(false)
+      expect(store.entities.filters.showCompleted).toBe(true)
+      
+      // Test custom getter
+      let filteredTodos = store.getFilteredTodos()
+      expect(filteredTodos).toHaveLength(2) // Both todos shown
+      
+      // Test custom actions
+      store.setLoading(true)
+      expect(store.entities.ui.isLoading).toBe(true)
+      
+      store.toggleFilter()
+      expect(store.entities.filters.showCompleted).toBe(false)
+      
+      // Test that getter responds to state changes
+      filteredTodos = store.getFilteredTodos()
+      expect(filteredTodos).toHaveLength(1) // Only incomplete todo shown
+    })
+  })
+
+  describe('Store Name Override', () => {
+    test('should allow custom store name', () => {
+      const useTodoStore = createPiniaEntityStore<Todo>('default-name', {
+        storeName: 'custom-name'
+      })
+
+      const store = useTodoStore()
+      // The store should work normally even with a custom name
+      expect(store.entities).toBeDefined()
+    })
+  })
+
+  describe('Type Safety', () => {
+    test('should maintain type safety with custom extensions', () => {
+      const useTodoStore = createPiniaEntityStore<Todo>('todos', {
+        getters: {
+          getTypedGetters: (store) => (id: number) => {
+            const todo = store.getOne()(id)
+            return todo ? todo.priority : null
+          }
+        },
+        actions: {
+          setTypedActions: (store) => (id: number, priority: Todo['priority']) => {
+            const current = store.getOne()(id)
+            if (current) {
+              store.updateOne(id, { ...current, priority })
+            }
+          }
+        }
+      })
+
+      const store = useTodoStore()
+      
+      // Add a todo first
+      const todo: Todo = { 
+        id: 1, 
+        title: 'Test', 
+        description: 'Test', 
+        completed: false, 
+        priority: 'medium', 
+        tags: [] 
+      }
+      store.createOne(todo)
+      
+      // This should compile without type errors
+      const priority = store.getTypedGetters(1)
+      store.setTypedActions(1, 'high')
+      
+      expect(priority).toBe('medium') // Should return the priority
+    })
+  })
+})

--- a/packages/pinia-adapter/src/index.test.ts
+++ b/packages/pinia-adapter/src/index.test.ts
@@ -1,0 +1,259 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, test } from 'vitest'
+import type { WithId } from '../../types/WithId.js'
+import { createPiniaEntityStore } from './index.js'
+
+// Test entity interface
+interface User extends WithId {
+  name: string
+  email: string
+  age: number
+}
+
+describe('Pinia Adapter', () => {
+  let pinia: ReturnType<typeof createPinia>
+  let useUserStore: ReturnType<typeof createPiniaEntityStore<User>>
+
+  beforeEach(() => {
+    pinia = createPinia()
+    setActivePinia(pinia)
+    useUserStore = createPiniaEntityStore<User>('users')
+  })
+
+  describe('Store Creation', () => {
+    test('should create a Pinia store with correct structure', () => {
+      const store = useUserStore()
+      
+      expect(store).toBeDefined()
+      expect(store.entities).toBeDefined()
+      expect(store.entities.byId).toBeDefined()
+      expect(store.entities.allIds).toBeDefined()
+      expect(store.entities.current).toBeNull()
+      expect(store.entities.currentById).toBeNull()
+      expect(store.entities.active).toEqual([])
+    })
+
+    test('should have all getter methods', () => {
+      const store = useUserStore()
+      
+      expect(typeof store.getAll).toBe('function')
+      expect(typeof store.getAllArray).toBe('function')
+      expect(typeof store.getAllIds).toBe('function')
+      expect(typeof store.getOne).toBe('function')
+      expect(typeof store.getMany).toBe('function')
+      expect(typeof store.getCurrent).toBe('function')
+      expect(typeof store.getCurrentById).toBe('function')
+      expect(typeof store.getActive).toBe('function')
+      expect(typeof store.getFirstActive).toBe('function')
+      expect(typeof store.getWhere).toBe('function')
+      expect(typeof store.getWhereArray).toBe('function')
+      expect(typeof store.getMissingIds).toBe('function')
+      expect(typeof store.getMissingEntities).toBe('function')
+      expect(typeof store.getIsEmpty).toBe('function')
+      expect(typeof store.getIsNotEmpty).toBe('function')
+    })
+
+    test('should have all action methods', () => {
+      const store = useUserStore()
+      
+      expect(typeof store.createOne).toBe('function')
+      expect(typeof store.createMany).toBe('function')
+      expect(typeof store.updateOne).toBe('function')
+      expect(typeof store.updateMany).toBe('function')
+      expect(typeof store.deleteOne).toBe('function')
+      expect(typeof store.deleteMany).toBe('function')
+      expect(typeof store.setCurrent).toBe('function')
+      expect(typeof store.removeCurrent).toBe('function')
+      expect(typeof store.setCurrentById).toBe('function')
+      expect(typeof store.removeCurrentById).toBe('function')
+      expect(typeof store.setActive).toBe('function')
+      expect(typeof store.resetActive).toBe('function')
+      expect(typeof store.setIsDirty).toBe('function')
+      expect(typeof store.setIsNotDirty).toBe('function')
+      expect(typeof store.updateField).toBe('function')
+    })
+  })
+
+  describe('Entity Management', () => {
+    test('should create and retrieve entities', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      
+      expect(store.entities.allIds).toContain(1)
+      expect(store.entities.byId[1]).toBeDefined()
+      expect(store.entities.byId[1]?.name).toBe('John')
+      expect(store.entities.byId[1]?.$isDirty).toBe(false)
+    })
+
+    test('should update existing entities', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      
+      const updatedUser: User = { id: 1, name: 'John Updated', email: 'john@example.com', age: 31 }
+      store.updateOne(1, updatedUser)
+      
+      expect(store.entities.byId[1]?.name).toBe('John Updated')
+      expect(store.entities.byId[1]?.age).toBe(31)
+      expect(store.entities.byId[1]?.$isDirty).toBe(true)
+    })
+
+    test('should delete entities', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      
+      expect(store.entities.allIds).toContain(1)
+      
+      store.deleteOne(1)
+      
+      expect(store.entities.allIds).not.toContain(1)
+      expect(store.entities.byId[1]).toBeUndefined()
+    })
+  })
+
+  describe('Current Entity Management', () => {
+    test('should set and retrieve current entity', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      store.setCurrent(user)
+      
+      expect(store.entities.current).toBeDefined()
+      expect(store.entities.current?.id).toBe(1)
+      expect(store.entities.current?.name).toBe('John')
+    })
+
+    test('should set and retrieve current entity by ID', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      store.setCurrentById(1)
+      
+      expect(store.entities.currentById).toBe(1)
+      expect(store.getCurrentById()?.id).toBe(1)
+    })
+  })
+
+  describe('Active Entities Management', () => {
+    test('should set entities as active', () => {
+      const store = useUserStore()
+      
+      const user1: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      const user2: User = { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 }
+      
+      store.createOne(user1)
+      store.createOne(user2)
+      store.setActive(1)
+      store.setActive(2)
+      
+      expect(store.entities.active).toContain(1)
+      expect(store.entities.active).toContain(2)
+      expect(store.entities.active).toHaveLength(2)
+    })
+
+    test('should not set non-existent entities as active', () => {
+      const store = useUserStore()
+      
+      store.setActive(999)
+      
+      expect(store.entities.active).not.toContain(999)
+      expect(store.entities.active).toHaveLength(0)
+    })
+
+    test('should reset active entities', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      store.setActive(1)
+      
+      expect(store.entities.active).toHaveLength(1)
+      
+      store.resetActive()
+      
+      expect(store.entities.active).toHaveLength(0)
+    })
+  })
+
+  describe('Dirty State Management', () => {
+    test('should mark entities as dirty', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      
+      expect(store.entities.byId[1]?.$isDirty).toBe(false)
+      
+      store.setIsDirty(1)
+      
+      expect(store.entities.byId[1]?.$isDirty).toBe(true)
+    })
+
+    test('should mark entities as not dirty', () => {
+      const store = useUserStore()
+      
+      const user: User = { id: 1, name: 'John', email: 'john@example.com', age: 30 }
+      store.createOne(user)
+      store.setIsDirty(1)
+      
+      expect(store.entities.byId[1]?.$isDirty).toBe(true)
+      
+      store.setIsNotDirty(1)
+      
+      expect(store.entities.byId[1]?.$isDirty).toBe(false)
+    })
+  })
+
+  describe('Integration', () => {
+    test('should handle complex workflow', () => {
+      const store = useUserStore()
+      
+      // Create multiple users
+      const users: User[] = [
+        { id: 1, name: 'John', email: 'john@example.com', age: 30 },
+        { id: 2, name: 'Jane', email: 'jane@example.com', age: 25 },
+        { id: 3, name: 'Bob', email: 'bob@example.com', age: 35 }
+      ]
+      
+      store.createMany(users)
+      
+      // Set current user
+      store.setCurrent(users[0])
+      store.setCurrentById(1)
+      
+      // Set active users
+      store.setActive(1)
+      store.setActive(2)
+      
+      // Update a user
+      store.updateOne(1, { ...users[0], name: 'John Updated' })
+      
+      // Update current entity to match the updated entity
+      store.setCurrent(store.entities.byId[1]!)
+      
+      // Verify state
+      expect(store.entities.allIds).toHaveLength(3)
+      expect(store.entities.current?.name).toBe('John Updated')
+      expect(store.entities.currentById).toBe(1)
+      expect(store.entities.active).toHaveLength(2)
+      expect(store.entities.byId[1]?.$isDirty).toBe(true)
+      
+      // Test getters
+      expect(store.getIsEmpty()).toBe(false)
+      expect(store.getAllIds()).toHaveLength(3)
+      expect(store.getOne()(1)?.name).toBe('John Updated')
+      
+      // Test filtering
+      const getWhere = store.getWhere()
+      const adults = getWhere(user => user.age >= 30)
+      expect(Object.keys(adults)).toHaveLength(2)
+    })
+  })
+})

--- a/packages/pinia-adapter/src/index.ts
+++ b/packages/pinia-adapter/src/index.ts
@@ -1,0 +1,110 @@
+import { defineStore } from 'pinia'
+import createActions from './core/createActions.js'
+import createGetters from './core/createGetters.js'
+import createState from './core/createState.js'
+import type { WithId } from './types/WithId.js'
+
+/**
+ * Base store type with entity management capabilities
+ */
+export type BaseEntityStore<T extends WithId> = {
+  entities: {
+    byId: Record<string, T & { $isDirty: boolean }>
+    allIds: string[]
+    current: (T & { $isDirty: boolean }) | null
+    currentById: string | null
+    active: string[]
+  }
+} & ReturnType<typeof createGetters<T>> &
+  ReturnType<typeof createActions<T>>
+
+/**
+ * Options for extending the Pinia entity store
+ */
+export interface PiniaEntityStoreOptions<T extends WithId> {
+  /**
+   * Additional state properties to add to the store
+   */
+  state?: Record<string, unknown>
+  
+  /**
+   * Additional getters to add to the store
+   */
+  getters?: Record<string, (store: BaseEntityStore<T>) => (...args: unknown[]) => unknown>
+  
+  /**
+   * Additional actions to add to the store
+   */
+  actions?: Record<string, (store: BaseEntityStore<T>) => (...args: unknown[]) => unknown>
+  
+  /**
+   * Custom store name (optional, defaults to the provided storeName)
+   */
+  storeName?: string
+}
+
+/**
+ * Creates a Pinia store with entity management capabilities
+ * @param storeName - The name of the Pinia store
+ * @param options - Options for extending the store
+ * @returns A Pinia store definition with entity management methods
+ */
+export function createPiniaEntityStore<T extends WithId>(
+  storeName: string,
+  options: PiniaEntityStoreOptions<T> = {}
+) {
+  return defineStore(options.storeName || storeName, () => {
+    // Create the base state using our core function
+    const baseState = createState<T>()
+    
+    // Create state by merging base state with custom state
+    const entities = {
+      ...baseState.entities,
+      ...options.state
+    }
+    
+    // Create a state object that the core functions can work with
+    const state = {
+      entities
+    }
+    
+    // Create getters and actions with the state
+    const getters = createGetters<T>(state)
+    const actions = createActions<T>(state)
+    
+    // Create the base store object
+    const baseStore: BaseEntityStore<T> = {
+      entities,
+      ...getters,
+      ...actions
+    } as BaseEntityStore<T>
+    
+    // Create custom getters as functions that receive the store context
+    const customGetters: Record<string, (...args: unknown[]) => unknown> = {}
+    if (options.getters) {
+      Object.entries(options.getters).forEach(([key, getterFn]) => {
+        customGetters[key] = (...args: unknown[]) => getterFn(baseStore)(...args)
+      })
+    }
+    
+    // Create custom actions as functions that receive the store context
+    const customActions: Record<string, (...args: unknown[]) => unknown> = {}
+    if (options.actions) {
+      Object.entries(options.actions).forEach(([key, actionFn]) => {
+        customActions[key] = (...args: unknown[]) => actionFn(baseStore)(...args)
+      })
+    }
+    
+    // Return the store with all functionality
+    return {
+      ...baseStore,
+      ...customGetters,
+      ...customActions,
+    }
+  })
+}
+
+/**
+ * Type for the Pinia entity store instance
+ */
+export type PiniaEntityStore<T extends WithId> = ReturnType<ReturnType<typeof createPiniaEntityStore<T>>>

--- a/packages/pinia-adapter/src/types/ByIdParams.ts
+++ b/packages/pinia-adapter/src/types/ByIdParams.ts
@@ -1,0 +1,6 @@
+import type { Id } from './WithId'
+
+export interface ByIdParams<T> {
+  id: Id
+  payload: T
+}

--- a/packages/pinia-adapter/src/types/Filter.ts
+++ b/packages/pinia-adapter/src/types/Filter.ts
@@ -1,0 +1,3 @@
+export type FilterFn<T> = (item: T) => boolean | null
+
+export type OptionalFilterFn<T> = FilterFn<T> | null

--- a/packages/pinia-adapter/src/types/State.ts
+++ b/packages/pinia-adapter/src/types/State.ts
@@ -1,0 +1,13 @@
+import type { Id, WithId } from './WithId'
+
+export interface State<T extends WithId> {
+  entities: {
+    byId: Record<Id, T & { $isDirty: boolean }>
+    allIds: Id[]
+    current: T & { $isDirty: boolean } | null
+    currentById: Id | null
+    active: Id[]
+  }
+}
+
+// export type CreatedEntity<T> = T & { $isDirty: boolean }

--- a/packages/pinia-adapter/src/types/WithId.ts
+++ b/packages/pinia-adapter/src/types/WithId.ts
@@ -1,0 +1,5 @@
+export interface WithId {
+  id: Id
+}
+
+export type Id = number | string

--- a/packages/pinia-adapter/src/types/index.ts
+++ b/packages/pinia-adapter/src/types/index.ts
@@ -1,0 +1,5 @@
+// Types package index file
+export type { Id, WithId } from './WithId.js';
+export type { State } from './State.js';
+export type { FilterFn, OptionalFilterFn } from './Filter.js';
+export type { ByIdParams } from './ByIdParams.js';

--- a/packages/pinia-adapter/tsconfig.json
+++ b/packages/pinia-adapter/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,0 +1,141 @@
+# @entity-store/types
+
+Shared types package for entity-store, defining all common interfaces and types.
+
+## Installation
+
+```bash
+npm install @entity-store/types
+# or
+pnpm add @entity-store/types
+# or
+yarn add @entity-store/types
+```
+
+## Available Types
+
+### WithId
+
+Base interface for all entities with a unique identifier.
+
+```typescript
+import type { WithId, Id } from '@entity-store/types'
+
+interface User extends WithId {
+  name: string
+  email: string
+  age: number
+}
+
+// WithId automatically adds:
+// - id: Id (string | number)
+// - $isDirty: boolean (for modification tracking)
+```
+
+### State
+
+Interface defining the entity state structure.
+
+```typescript
+import type { State } from '@entity-store/types'
+
+interface State<T> {
+  entities: {
+    byId: Record<string, T>           // Entities indexed by ID
+    allIds: string[]                  // List of all IDs
+    current: T | null                 // Currently selected entity
+    currentById: string | null        // ID of current entity
+    active: string[]                  // List of active IDs
+  }
+}
+```
+
+### Filter
+
+Types for entity filtering functions.
+
+```typescript
+import type { FilterFn, OptionalFilterFn } from '@entity-store/types'
+
+// Required filtering function
+type FilterFn<T> = (entity: T) => boolean
+
+// Optional filtering function
+type OptionalFilterFn<T> = (entity: T) => boolean | null
+
+// Usage example
+const filterAdults: FilterFn<User> = (user) => user.age >= 18
+const filterByName: OptionalFilterFn<User> = (user) => 
+  user.name.includes('John') ? true : null
+```
+
+### ByIdParams
+
+Interface for ID-based search parameters.
+
+```typescript
+import type { ByIdParams } from '@entity-store/types'
+
+interface ByIdParams {
+  id: string | number
+}
+```
+
+## Usage
+
+### Create an entity interface
+
+```typescript
+import type { WithId } from '@entity-store/types'
+
+interface Product extends WithId {
+  name: string
+  price: number
+  category: string
+  inStock: boolean
+}
+
+// Product interface will automatically have:
+// - id: string | number
+// - $isDirty: boolean
+```
+
+### Usage with core
+
+```typescript
+import type { State, WithId } from '@entity-store/types'
+import { createState } from '@entity-store/core'
+
+interface User extends WithId {
+  name: string
+  email: string
+}
+
+// Create typed state
+const state: State<User> = createState<User>()
+```
+
+### Usage with adapters
+
+```typescript
+import type { WithId } from '@entity-store/types'
+import { createPiniaEntityStore } from '@entity-store/pinia-adapter'
+
+interface Post extends WithId {
+  title: string
+  content: string
+  authorId: string
+  publishedAt: Date
+}
+
+// Create typed Pinia store
+const usePostStore = createPiniaEntityStore<Post>('posts')
+```
+
+## Benefits
+
+- **Centralized**: All types in one place
+- **Reusable**: Used by all packages
+- **Type-safe**: Fully typed with TypeScript
+- **Consistent**: Same structure everywhere
+- **Maintainable**: Centralized modifications

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@entity-store/types",
+  "version": "1.0.0",
+  "description": "Shared types and interfaces for entity-store",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "keywords": [
+    "typescript",
+    "types",
+    "entity-management"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^24.3.0",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/types/src/ByIdParams.ts
+++ b/packages/types/src/ByIdParams.ts
@@ -1,0 +1,6 @@
+import type { Id } from './WithId'
+
+export interface ByIdParams<T> {
+  id: Id
+  payload: T
+}

--- a/packages/types/src/Filter.ts
+++ b/packages/types/src/Filter.ts
@@ -1,0 +1,3 @@
+export type FilterFn<T> = (item: T) => boolean | null
+
+export type OptionalFilterFn<T> = FilterFn<T> | null

--- a/packages/types/src/State.ts
+++ b/packages/types/src/State.ts
@@ -1,0 +1,13 @@
+import type { Id, WithId } from './WithId'
+
+export interface State<T extends WithId> {
+  entities: {
+    byId: Record<Id, T & { $isDirty: boolean }>
+    allIds: Id[]
+    current: T & { $isDirty: boolean } | null
+    currentById: Id | null
+    active: Id[]
+  }
+}
+
+// export type CreatedEntity<T> = T & { $isDirty: boolean }

--- a/packages/types/src/WithId.ts
+++ b/packages/types/src/WithId.ts
@@ -1,0 +1,5 @@
+export interface WithId {
+  id: Id
+}
+
+export type Id = number | string

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,6 @@
+// Types package index file
+export type { ByIdParams } from './ByIdParams.js';
+export type { FilterFn, OptionalFilterFn } from './Filter.js';
+export type { State } from './State.js';
+export type { Id, WithId } from './WithId.js';
+

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,74 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(jsdom@26.1.0)
 
+  packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@24.3.0)(jiti@2.5.1)(jsdom@26.1.0))
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(jsdom@26.1.0)
+
+  packages/main:
+    dependencies:
+      '@entity-store/core':
+        specifier: workspace:*
+        version: link:../core
+      '@entity-store/pinia-adapter':
+        specifier: workspace:*
+        version: link:../pinia-adapter
+      '@entity-store/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
+  packages/pinia-adapter:
+    dependencies:
+      '@entity-store/core':
+        specifier: workspace:*
+        version: link:../core
+      '@entity-store/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@24.3.0)(jiti@2.5.1)(jsdom@26.1.0))
+      pinia:
+        specifier: ^3.0.3
+        version: 3.0.3(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2))
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(jsdom@26.1.0)
+
+  packages/types:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.3.0
+        version: 24.3.0
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
+packages:
+  - 'packages/*'
+  - 'examples/*'
+  - 'docs/*'
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
- Convert single package to monorepo structure
- Create separate packages: core, types, pinia-adapter, main
- Add comprehensive documentation in English for all packages
- Create installation guide and usage examples
- Configure pnpm workspace for package management
- Maintain all existing functionality and tests
- Enable tree-shaking and modular usage